### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,4 +1,4 @@
-name: Upload PyPI package release
+name: Packaging
 
 on:
   push:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -37,7 +37,7 @@ jobs:
         run: poetry run poe build
 
       - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
           user: __token__
@@ -46,7 +46,7 @@ jobs:
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -33,7 +33,8 @@ jobs:
       - run: poetry install
 
       - name: Build
-        run: poetry build
+        # I use poetry just as a package manager, so this is not `poetry build`
+        run: poetry run poe build
 
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,6 +21,15 @@ jobs:
       - name: Set up poetry
         uses: abatilo/actions-poetry@v2
 
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-build-${{ matrix.python }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ matrix.python }}-${{ hashFiles('**/poetry.lock') }}
+            ${{ runner.os }}-build-${{ matrix.python }}-
+            ${{ runner.os }}-
       - run: poetry install
 
       - name: Build

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,4 +1,4 @@
-name: Lint and Test Python
+name: Test
 on: [push]
 
 jobs:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,7 +22,6 @@ jobs:
         uses: abatilo/actions-poetry@v2
 
       - name: Cache
-        id: cache-python
         uses: actions/cache@v3
         with:
           path: ~/.cache/pypoetry/virtualenvs
@@ -31,9 +30,7 @@ jobs:
             ${{ runner.os }}-build-${{ matrix.python }}-${{ hashFiles('**/poetry.lock') }}
             ${{ runner.os }}-build-${{ matrix.python }}-
             ${{ runner.os }}-
-
-      - if: ${{ steps.cache-python.outputs.cache-hit != 'true' }}
-        name: Install dependencies
+      - name: Install dependencies
         run: poetry install
 
       - name: Lint
@@ -47,7 +44,6 @@ jobs:
             echo "Expected $expected_version, but got $actual_version"
             exit 1
           fi
-
       - name: Test
         run: poetry run poe test
 

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ You can express periodicity such as morning, noon, and night.
 
 # License
 
-MIT
+BSD 3-Clause License

--- a/poetry.lock
+++ b/poetry.lock
@@ -56,6 +56,30 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "build"
+version = "0.10.0"
+description = "A simple, correct Python build frontend"
+category = "dev"
+optional = false
+python-versions = ">= 3.7"
+files = [
+    {file = "build-0.10.0-py3-none-any.whl", hash = "sha256:af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171"},
+    {file = "build-0.10.0.tar.gz", hash = "sha256:d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "os_name == \"nt\""}
+packaging = ">=19.0"
+pyproject_hooks = "*"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["furo (>=2021.08.31)", "sphinx (>=4.0,<5.0)", "sphinx-argparse-cli (>=1.5)", "sphinx-autodoc-typehints (>=1.10)"]
+test = ["filelock (>=3)", "pytest (>=6.2.4)", "pytest-cov (>=2.12)", "pytest-mock (>=2)", "pytest-rerunfailures (>=9.1)", "pytest-xdist (>=1.34)", "setuptools (>=42.0.0)", "setuptools (>=56.0.0)", "toml (>=0.10.0)", "wheel (>=0.36.0)"]
+typing = ["importlib-metadata (>=5.1)", "mypy (==0.991)", "tomli", "typing-extensions (>=3.7.4.3)"]
+virtualenv = ["virtualenv (>=20.0.35)"]
+
+[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
@@ -436,6 +460,21 @@ files = [
 ]
 
 [[package]]
+name = "pyproject-hooks"
+version = "1.0.0"
+description = "Wrappers to call pyproject.toml-based build backend hooks."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyproject_hooks-1.0.0-py3-none-any.whl", hash = "sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8"},
+    {file = "pyproject_hooks-1.0.0.tar.gz", hash = "sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5"},
+]
+
+[package.dependencies]
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "pytest"
 version = "7.2.1"
 description = "pytest: simple powerful testing with Python"
@@ -494,6 +533,45 @@ files = [
 tokenize-rt = ">=3.2.0"
 
 [[package]]
+name = "setuptools"
+version = "66.1.1"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
+    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
+name = "setuptools-scm"
+version = "7.1.0"
+description = "the blessed package to manage your versions by scm tags"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools_scm-7.1.0-py3-none-any.whl", hash = "sha256:73988b6d848709e2af142aa48c986ea29592bbcfca5375678064708205253d8e"},
+    {file = "setuptools_scm-7.1.0.tar.gz", hash = "sha256:6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27"},
+]
+
+[package.dependencies]
+packaging = ">=20.0"
+setuptools = "*"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+typing-extensions = "*"
+
+[package.extras]
+test = ["pytest (>=6.2)", "virtualenv (>20)"]
+toml = ["setuptools (>=42)"]
+
+[[package]]
 name = "tokenize-rt"
 version = "5.0.0"
 description = "A wrapper around the stdlib `tokenize` which roundtrips."
@@ -532,4 +610,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "10579024456dbab9c45258e2dada4cd55b9779bd23ada388e1535b0edced7c17"
+content-hash = "6be7ed79881c83c12b7b05abcec35f33e985b03d8cf384bfa1ec071c85669cf1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,22 @@
 line-length = 79
 
 [tool.poetry]
+# I use poetry as just a package manager.
+# So, I only write the settings that poetry needs.
+# The actual package metadata is written in setup.cfg.
+# I use pypa/build for packaging.
 name = "timevec"
-version = "0.0.0"  # replace by poetry-dynamic-versioning
+version = "0.0.0"
 description = ""
-authors = ["kitsuyui <kitsuyui@kitsuyui.com>"]
-readme = "README.md"
-packages = [{ include = "timevec", from = "./" }]
+authors = []
+packages = [
+    { include = "timevec" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"
 numpy = "^1.24.1"
+
 [tool.poetry.group.dev.dependencies]
 black = "*"
 pytest = "*"
@@ -21,25 +27,42 @@ pytest-cov = "*"
 flake8 = "*"
 mypy = "*"
 poethepoet = "*"
+setuptools-scm = "*"
+build = "*"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry_dynamic_versioning.backend"
+requires = [
+    "setuptools", "setuptools_scm"
+]
+build-backend = "setuptools.build_meta"
 
-[tool.poetry-dynamic-versioning]
-enable = true
+[tool.setuptools_scm]
+write_to = "timevec/_version.py"
 
 [tool.poe.tasks]
-test = { shell = "python -m pytest" }
-coverage-xml = "python -m pytest --cov=timevec tests --doctest-modules --cov-report=xml"
-format = { shell = """
-isort timevec tests &&
-black timevec tests &&
-pyupgrade --py38-plus timevec/*.py tests/*.py
-""" }
-check = { shell = """
-isort --check-only --diff timevec tests &&
-black --check --diff timevec tests &&
-flake8 timevec tests &&
-mypy timevec tests
-""" }
+test = "pytest"
+coverage-xml = "pytest --cov=timevec --doctest-modules --cov-report=xml"
+format = [
+    { cmd = "isort timevec"},
+    { cmd = "black timevec"},
+    { cmd = "pyupgrade --py38-plus timevec/*.py"},
+]
+check = [
+    { cmd = "isort --check-only --diff timevec"},
+    { cmd = "black --check --diff timevec"},
+    { cmd = "flake8 timevec"},
+    { cmd = "mypy timevec"},
+]
+build = [
+    { cmd = "python -m build"}
+]
+[tool.mypy]
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+ignore_missing_imports = false
+
+[tool.mypy-tests."*"]
+disallow_untyped_defs = false
+warn_return_any = false
+ignore_missing_imports = true


### PR DESCRIPTION
Current configuration does not work as expected.
Therefore, it is not possible to release the package stably. For example, it is released on PyPI with a version different from the version specified by the tag.
Take the results of the trial in https://github.com/kitsuyui/pypi-playground .
