### PR TITLE
Fix a bug of boundary value

### DIFF
--- a/tests/test_builtin_math.py
+++ b/tests/test_builtin_math.py
@@ -90,3 +90,27 @@ def test_day_vec() -> None:
     dt = datetime.datetime(2023, 1, 2, 23, 59, 59, 999999)
     x, y = day_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
+
+
+def test_edge_cases() -> None:
+    # beginning of year
+    dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
+    x, y = year_vec(dt)
+    assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
+
+    dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
+    x, y = month_vec(dt)
+    assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
+
+    dt = datetime.datetime(2023, 1, 2, 0, 0, 0)
+    x, y = week_vec(dt)
+    assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
+
+    dt = datetime.datetime(2023, 1, 2, 0, 0, 0)
+    x, y = day_vec(dt)
+    assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
+
+    # end of year
+    dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
+    x, y = year_vec(dt)
+    assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -72,3 +72,40 @@ def test_day_vec() -> None:
     dt = datetime.datetime(2023, 1, 1, 12, 0, 0)
     vec = day_vec(dt)
     assert vec == pytest.approx(np.array([-1.0, 0.0]), abs=1e-6)
+
+
+def test_edge_cases() -> None:
+    # beginning of year
+    dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
+    vec = year_vec(dt)
+    assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
+
+    dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
+    vec = month_vec(dt)
+    assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
+
+    dt = datetime.datetime(2023, 1, 2, 0, 0, 0)  # Monday
+    vec = week_vec(dt)
+    assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
+
+    dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
+    vec = day_vec(dt)
+    assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
+
+    # end of year
+    dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
+    vec = year_vec(dt)
+    assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
+
+    dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
+    vec = month_vec(dt)
+    assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-5)
+
+    dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
+    vec = day_vec(dt)
+    assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-4)
+
+    # end of month
+    dt = datetime.datetime(2023, 1, 31, 23, 59, 59, 999999)
+    vec = month_vec(dt)
+    assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-5)

--- a/timevec/builtin_math.py
+++ b/timevec/builtin_math.py
@@ -1,3 +1,4 @@
+import calendar
 import datetime
 import math
 from typing import Tuple
@@ -5,8 +6,12 @@ from typing import Tuple
 
 def year_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the year as a vector"""
-    begin_of_year = datetime.datetime.min.replace(year=dt.year)
-    end_of_year = datetime.datetime.min.replace(year=dt.year + 1)
+    begin_of_year = datetime.datetime.min.replace(
+        year=dt.year, month=1, day=1, hour=0, minute=0, second=0
+    )
+    end_of_year = datetime.datetime.min.replace(
+        year=dt.year + 1, month=1, day=1, hour=0, minute=0, second=0
+    )
     rate = time_elapsed_ratio(begin=begin_of_year, end=end_of_year, current=dt)
     return ratio_to_vec(rate)
 
@@ -14,11 +19,12 @@ def year_vec(dt: datetime.datetime) -> Tuple[float, float]:
 def month_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the month as a vector"""
     begin_of_month = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month
+        year=dt.year, month=dt.month, day=1, hour=0, minute=0, second=0
     )
+    _, last_day = calendar.monthrange(dt.year, dt.month)
     end_of_month = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month + 1
-    )
+        year=dt.year, month=dt.month, day=last_day, hour=0, minute=0, second=0
+    ) + datetime.timedelta(days=1)
     rate = time_elapsed_ratio(
         begin=begin_of_month, end=end_of_month, current=dt
     )
@@ -29,10 +35,10 @@ def week_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the week as a vector"""
     # weekday is 0 for Monday and 6 for Sunday
     begin_of_week = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month, day=dt.day
+        year=dt.year, month=dt.month, day=dt.day, hour=0, minute=0, second=0
     ) - datetime.timedelta(days=dt.weekday())
     end_of_week = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month, day=dt.day
+        year=dt.year, month=dt.month, day=dt.day, hour=0, minute=0, second=0
     ) + datetime.timedelta(days=7 - dt.weekday())
     rate = time_elapsed_ratio(begin=begin_of_week, end=end_of_week, current=dt)
     return ratio_to_vec(rate)
@@ -41,10 +47,10 @@ def week_vec(dt: datetime.datetime) -> Tuple[float, float]:
 def day_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the day as a vector"""
     begin_of_day = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month, day=dt.day
+        year=dt.year, month=dt.month, day=dt.day, hour=0, minute=0, second=0
     )
     end_of_day = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month, day=dt.day
+        year=dt.year, month=dt.month, day=dt.day, hour=0, minute=0, second=0
     ) + datetime.timedelta(days=1)
     rate = time_elapsed_ratio(begin=begin_of_day, end=end_of_day, current=dt)
     return ratio_to_vec(rate)

--- a/timevec/numpy.py
+++ b/timevec/numpy.py
@@ -1,3 +1,4 @@
+import calendar
 import datetime
 
 import numpy as np
@@ -10,8 +11,12 @@ def year_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the year as a vector"""
-    begin_of_year = datetime.datetime.min.replace(year=dt.year)
-    end_of_year = datetime.datetime.min.replace(year=dt.year + 1)
+    begin_of_year = datetime.datetime(
+        dt.year, month=1, day=1, hour=0, minute=0, second=0
+    )
+    end_of_year = datetime.datetime(
+        dt.year + 1, month=1, day=1, hour=0, minute=0, second=0
+    )
     rate = time_elapsed_ratio(
         begin=begin_of_year,
         end=end_of_year,
@@ -24,12 +29,13 @@ def month_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the month as a vector"""
-    begin_of_month = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month
+    begin_of_month = datetime.datetime(
+        year=dt.year, month=dt.month, day=1, hour=0, minute=0, second=0
     )
-    end_of_month = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month + 1
-    )
+    _, last_day = calendar.monthrange(dt.year, dt.month)
+    end_of_month = datetime.datetime(
+        year=dt.year, month=dt.month, day=last_day, hour=0, minute=0, second=0
+    ) + datetime.timedelta(days=1)
     rate = time_elapsed_ratio(
         begin=begin_of_month,
         end=end_of_month,
@@ -43,10 +49,20 @@ def week_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the week as a vector"""
     begin_of_week = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month, day=dt.day
+        year=dt.year,
+        month=dt.month,
+        day=dt.day,
+        hour=0,
+        minute=0,
+        second=0,
     ) - datetime.timedelta(days=dt.weekday())
     end_of_week = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month, day=dt.day
+        year=dt.year,
+        month=dt.month,
+        day=dt.day,
+        hour=0,
+        minute=0,
+        second=0,
     ) + datetime.timedelta(days=7 - dt.weekday())
     rate = time_elapsed_ratio(
         begin=begin_of_week,
@@ -61,11 +77,21 @@ def day_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the day as a vector"""
     begin_of_day = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month, day=dt.day
+        year=dt.year,
+        month=dt.month,
+        day=dt.day,
+        hour=0,
+        minute=0,
+        second=0,
     )
     end_of_day = datetime.datetime.min.replace(
-        year=dt.year, month=dt.month, day=dt.day + 1
-    )
+        year=dt.year,
+        month=dt.month,
+        day=dt.day,
+        hour=0,
+        minute=0,
+        second=0,
+    ) + datetime.timedelta(days=1)
     rate = time_elapsed_ratio(
         begin=begin_of_day,
         end=end_of_day,


### PR DESCRIPTION
- There was an error in the handling of the boundary value.
- If you specify a month that does not exist, such as 13, an error occurs.
- Fix so that such errors do not occur.
