### PR TITLE
Reverse Conversion: Create datetime from vector

### DIFF
--- a/tests/test_builtin_math.py
+++ b/tests/test_builtin_math.py
@@ -2,7 +2,10 @@ import datetime
 
 import pytest
 
-from timevec.builtin_math import day_vec, month_vec, week_vec, year_vec
+from timevec.builtin_math import (
+    day_vec, month_vec, week_vec, year_vec,
+    datetime_from_vec,
+)
 
 
 def test_year_vec() -> None:
@@ -114,3 +117,11 @@ def test_edge_cases() -> None:
     dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
     x, y = year_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
+
+
+def test_datetime_from_vec() -> None:
+    dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
+    yv = year_vec(dt)
+    dv = day_vec(dt)
+    dt2 = datetime_from_vec(2023, yv, dv)
+    assert pytest.approx(dt, abs=1e-6) == dt2

--- a/tests/test_many_dates.py
+++ b/tests/test_many_dates.py
@@ -4,6 +4,8 @@ import timevec.builtin_math as tv
 import numpy as np
 import datetime
 
+import pytest
+
 
 def test_many_dates() -> None:
     # start 1-01-01
@@ -12,20 +14,23 @@ def test_many_dates() -> None:
     # try all the functions does not raise an exception
     for i in range(50000):
         dt += datetime.timedelta(days=17, hours=13, minutes=11, seconds=7)
-        tv.year_vec(dt)
+        yv = tv.year_vec(dt)
         tv.month_vec(dt)
         tv.week_vec(dt)
-        tv.day_vec(dt)
+        dv = tv.day_vec(dt)
+        assert pytest.approx(dt) == tv.datetime_from_vec(dt.year, yv, dv)
 
-        tvn.year_vec(dt)
+        yvn = tvn.year_vec(dt)
         tvn.month_vec(dt)
         tvn.week_vec(dt)
-        tvn.day_vec(dt)
+        dvn = tvn.day_vec(dt)
+        assert pytest.approx(dt) == tvn.datetime_from_vec(dt.year, yvn, dvn)
 
-        tv64.year_vec(np.datetime64(dt))
+        yv64 = tv64.year_vec(np.datetime64(dt))
         tv64.month_vec(np.datetime64(dt))
         tv64.week_vec(np.datetime64(dt))
-        tv64.day_vec(np.datetime64(dt))
+        dv64 = tv64.day_vec(np.datetime64(dt))
+        assert pytest.approx(np.datetime64(dt)) == tv64.datetime64_from_vec(dt.year, yv64, dv64)
 
     # tested up to 2100-01-01
     assert dt >= datetime.datetime(2400, 1, 1, 0, 0, 0)

--- a/timevec/builtin_math.py
+++ b/timevec/builtin_math.py
@@ -1,3 +1,4 @@
+import calendar
 import datetime
 import math
 from typing import Tuple
@@ -47,3 +48,24 @@ def ratio_to_vec(rate: float) -> Tuple[float, float]:
     x = math.cos(s)
     y = math.sin(s)
     return x, y
+
+
+def vec_to_ratio(x: float, y: float) -> float:
+    # atan2 returns a value in the range [-pi, pi]
+    # so we need to convert it to the range [0, 2*pi]
+    angle = math.atan2(y, x) / (2.0 * math.pi)
+    return angle if angle >= 0 else angle + 1.0
+
+
+def datetime_from_vec(
+    year: int,
+    yv: Tuple[float, float],
+    dv: Tuple[float, float],
+) -> datetime.datetime:
+    position_in_year = vec_to_ratio(*yv)
+    position_in_day = vec_to_ratio(*dv)
+    d = int(position_in_year * (366.0 if calendar.isleap(year) else 365.0))
+    s = position_in_day * 86400.0
+    return datetime.datetime(year, 1, 1, 0, 0, 0, 0) + datetime.timedelta(
+        days=int(d), seconds=s
+    )

--- a/timevec/numpy.py
+++ b/timevec/numpy.py
@@ -1,3 +1,4 @@
+import calendar
 import datetime
 
 import numpy as np
@@ -72,3 +73,24 @@ def ratio_to_vec(
     vec[0] = np.cos(2.0 * np.pi * ratio)
     vec[1] = np.sin(2.0 * np.pi * ratio)
     return vec
+
+
+def vec_to_ratio(arr: npt.NDArray) -> float:
+    """Convert a vector to a ratio"""
+    # atan2 returns a value in the range [-pi, pi]
+    # so we need to convert it to the range [0, 2*pi]
+    base = np.arctan2(arr[1], arr[0]) / (2.0 * np.pi)
+    return float(base if base >= 0.0 else base + 1.0)
+
+
+def datetime_from_vec(
+    year: int,
+    yv: npt.NDArray,
+    dv: npt.NDArray,
+) -> datetime.datetime:
+    position_in_year = vec_to_ratio(yv)
+    position_in_day = vec_to_ratio(dv)
+    d = int(position_in_year * (366.0 if calendar.isleap(year) else 365.0))
+    s = position_in_day * 86400.0
+    delta = datetime.timedelta(days=d, seconds=s)
+    return datetime.datetime(year, 1, 1, 0, 0, 0, 0) + delta

--- a/timevec/numpy_datetime64.py
+++ b/timevec/numpy_datetime64.py
@@ -3,7 +3,7 @@ import datetime
 import numpy as np
 import numpy.typing as npt
 
-from timevec.numpy import ratio_to_vec
+from timevec.numpy import datetime_from_vec, ratio_to_vec
 from timevec.util import (
     day_range,
     month_range,
@@ -76,3 +76,13 @@ def datetime64_to_datetime(dt: np.datetime64) -> datetime.datetime:
         (dt64 - np.datetime64("1970-01-01T00:00:00")) / np.timedelta64(1, "s")
     )
     return datetime.datetime.utcfromtimestamp(ts)
+
+
+def datetime64_from_vec(
+    year: int,
+    yv: npt.NDArray,
+    dv: npt.NDArray,
+) -> np.datetime64:
+    """Convert a vector representation of a datetime to a numpy.datetime64"""
+    dt = datetime_from_vec(year, yv, dv)
+    return np.datetime64(dt)


### PR DESCRIPTION
We can create year_vec and day_vec to represent the position in the year and the position in the day.
Then, we can create datetime from them.

```python
import timevec.builtin_math as tv
import datetime
dt = datetime.datetime.now()
yv = tv.year_vec(dt)
dv = tv.day_vec(dt)
dt2 = tv.datetime_from_vec(dt.year, yv, dv)
assert dt == dt2  # This is true (but there may be a small floating point error)
```
