### PR TITLE
Implement smooth conversion of vectors and times

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,16 @@ vec = tv.year_vec(dt)
 # array([1., 0.])
 ```
 
-# Functions
+# Modules
 
 - `timevec.numpy` provides functions that return numpy.ndarray.
+- `timevec.numpy_datetime64` provides functions that return numpy.datetime64.
 - `timevec.builtin_math` provides functions that return tuple of float.
+
+# Functions
+
+Almost same functions are provided in `timevec.numpy`, `timevec.numpy_datetime64`, and `timevec.builtin_math`.
+The difference is the return type.
 
 ## year_vec
 
@@ -87,6 +93,13 @@ This is a vector that has periodicity in a day.
 You can express periodicity such as morning, noon, and night.
 ![day_vec](https://user-images.githubusercontent.com/2596972/213921566-dd69416e-2816-4c3d-9808-b3f87a51e543.svg)
 
+
+## Others
+
+- `long_time_vec` ... 1 to 5001 years period
+- `millenium_vec` ... one millenium (1000 years) period
+- `century_vec` ... one century (100 years) period
+- `decade_vec` ... one decade (10 years) period
 
 # License
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,32 +21,46 @@ tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy
 
 [[package]]
 name = "black"
-version = "22.12.0"
+version = "23.1.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
-    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
-    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
-    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
-    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
-    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
-    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
-    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
-    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
-    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
-    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
-    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
+    {file = "black-23.1.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:b6a92a41ee34b883b359998f0c8e6eb8e99803aa8bf3123bf2b2e6fec505a221"},
+    {file = "black-23.1.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:57c18c5165c1dbe291d5306e53fb3988122890e57bd9b3dcb75f967f13411a26"},
+    {file = "black-23.1.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:9880d7d419bb7e709b37e28deb5e68a49227713b623c72b2b931028ea65f619b"},
+    {file = "black-23.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6663f91b6feca5d06f2ccd49a10f254f9298cc1f7f49c46e498a0771b507104"},
+    {file = "black-23.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:9afd3f493666a0cd8f8df9a0200c6359ac53940cbde049dcb1a7eb6ee2dd7074"},
+    {file = "black-23.1.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:bfffba28dc52a58f04492181392ee380e95262af14ee01d4bc7bb1b1c6ca8d27"},
+    {file = "black-23.1.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c1c476bc7b7d021321e7d93dc2cbd78ce103b84d5a4cf97ed535fbc0d6660648"},
+    {file = "black-23.1.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:382998821f58e5c8238d3166c492139573325287820963d2f7de4d518bd76958"},
+    {file = "black-23.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bf649fda611c8550ca9d7592b69f0637218c2369b7744694c5e4902873b2f3a"},
+    {file = "black-23.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:121ca7f10b4a01fd99951234abdbd97728e1240be89fde18480ffac16503d481"},
+    {file = "black-23.1.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:a8471939da5e824b891b25751955be52ee7f8a30a916d570a5ba8e0f2eb2ecad"},
+    {file = "black-23.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8178318cb74f98bc571eef19068f6ab5613b3e59d4f47771582f04e175570ed8"},
+    {file = "black-23.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:a436e7881d33acaf2536c46a454bb964a50eff59b21b51c6ccf5a40601fbef24"},
+    {file = "black-23.1.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:a59db0a2094d2259c554676403fa2fac3473ccf1354c1c63eccf7ae65aac8ab6"},
+    {file = "black-23.1.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:0052dba51dec07ed029ed61b18183942043e00008ec65d5028814afaab9a22fd"},
+    {file = "black-23.1.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:49f7b39e30f326a34b5c9a4213213a6b221d7ae9d58ec70df1c4a307cf2a1580"},
+    {file = "black-23.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:162e37d49e93bd6eb6f1afc3e17a3d23a823042530c37c3c42eeeaf026f38468"},
+    {file = "black-23.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b70eb40a78dfac24842458476135f9b99ab952dd3f2dab738c1881a9b38b753"},
+    {file = "black-23.1.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:a29650759a6a0944e7cca036674655c2f0f63806ddecc45ed40b7b8aa314b651"},
+    {file = "black-23.1.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:bb460c8561c8c1bec7824ecbc3ce085eb50005883a6203dcfb0122e95797ee06"},
+    {file = "black-23.1.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:c91dfc2c2a4e50df0026f88d2215e166616e0c80e86004d0003ece0488db2739"},
+    {file = "black-23.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a951cc83ab535d248c89f300eccbd625e80ab880fbcfb5ac8afb5f01a258ac9"},
+    {file = "black-23.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:0680d4380db3719ebcfb2613f34e86c8e6d15ffeabcf8ec59355c5e7b85bb555"},
+    {file = "black-23.1.0-py3-none-any.whl", hash = "sha256:7a0f701d314cfa0896b9001df70a530eb2472babb76086344e688829efd97d32"},
+    {file = "black-23.1.0.tar.gz", hash = "sha256:b0bd97bea8903f5a2ba7219257a44e3f1f9d00073d6cc1add68f0beec69692ac"},
 ]
 
 [package.dependencies]
 click = ">=8.0.0"
 mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
@@ -183,63 +197,63 @@ test-no-images = ["pytest"]
 
 [[package]]
 name = "coverage"
-version = "7.0.5"
+version = "7.1.0"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "coverage-7.0.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2a7f23bbaeb2a87f90f607730b45564076d870f1fb07b9318d0c21f36871932b"},
-    {file = "coverage-7.0.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c18d47f314b950dbf24a41787ced1474e01ca816011925976d90a88b27c22b89"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef14d75d86f104f03dea66c13188487151760ef25dd6b2dbd541885185f05f40"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66e50680e888840c0995f2ad766e726ce71ca682e3c5f4eee82272c7671d38a2"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9fed35ca8c6e946e877893bbac022e8563b94404a605af1d1e6accc7eb73289"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d8d04e755934195bdc1db45ba9e040b8d20d046d04d6d77e71b3b34a8cc002d0"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7e109f1c9a3ece676597831874126555997c48f62bddbcace6ed17be3e372de8"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0a1890fca2962c4f1ad16551d660b46ea77291fba2cc21c024cd527b9d9c8809"},
-    {file = "coverage-7.0.5-cp310-cp310-win32.whl", hash = "sha256:be9fcf32c010da0ba40bf4ee01889d6c737658f4ddff160bd7eb9cac8f094b21"},
-    {file = "coverage-7.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:cbfcba14a3225b055a28b3199c3d81cd0ab37d2353ffd7f6fd64844cebab31ad"},
-    {file = "coverage-7.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:30b5fec1d34cc932c1bc04017b538ce16bf84e239378b8f75220478645d11fca"},
-    {file = "coverage-7.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1caed2367b32cc80a2b7f58a9f46658218a19c6cfe5bc234021966dc3daa01f0"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d254666d29540a72d17cc0175746cfb03d5123db33e67d1020e42dae611dc196"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19245c249aa711d954623d94f23cc94c0fd65865661f20b7781210cb97c471c0"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b05ed4b35bf6ee790832f68932baf1f00caa32283d66cc4d455c9e9d115aafc"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:29de916ba1099ba2aab76aca101580006adfac5646de9b7c010a0f13867cba45"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:e057e74e53db78122a3979f908973e171909a58ac20df05c33998d52e6d35757"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:411d4ff9d041be08fdfc02adf62e89c735b9468f6d8f6427f8a14b6bb0a85095"},
-    {file = "coverage-7.0.5-cp311-cp311-win32.whl", hash = "sha256:52ab14b9e09ce052237dfe12d6892dd39b0401690856bcfe75d5baba4bfe2831"},
-    {file = "coverage-7.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:1f66862d3a41674ebd8d1a7b6f5387fe5ce353f8719040a986551a545d7d83ea"},
-    {file = "coverage-7.0.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b69522b168a6b64edf0c33ba53eac491c0a8f5cc94fa4337f9c6f4c8f2f5296c"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:436e103950d05b7d7f55e39beeb4d5be298ca3e119e0589c0227e6d0b01ee8c7"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b8c56bec53d6e3154eaff6ea941226e7bd7cc0d99f9b3756c2520fc7a94e6d96"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a38362528a9115a4e276e65eeabf67dcfaf57698e17ae388599568a78dcb029"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:f67472c09a0c7486e27f3275f617c964d25e35727af952869dd496b9b5b7f6a3"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:220e3fa77d14c8a507b2d951e463b57a1f7810a6443a26f9b7591ef39047b1b2"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ecb0f73954892f98611e183f50acdc9e21a4653f294dfbe079da73c6378a6f47"},
-    {file = "coverage-7.0.5-cp37-cp37m-win32.whl", hash = "sha256:d8f3e2e0a1d6777e58e834fd5a04657f66affa615dae61dd67c35d1568c38882"},
-    {file = "coverage-7.0.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9e662e6fc4f513b79da5d10a23edd2b87685815b337b1a30cd11307a6679148d"},
-    {file = "coverage-7.0.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:790e4433962c9f454e213b21b0fd4b42310ade9c077e8edcb5113db0818450cb"},
-    {file = "coverage-7.0.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:49640bda9bda35b057b0e65b7c43ba706fa2335c9a9896652aebe0fa399e80e6"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d66187792bfe56f8c18ba986a0e4ae44856b1c645336bd2c776e3386da91e1dd"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:276f4cd0001cd83b00817c8db76730938b1ee40f4993b6a905f40a7278103b3a"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95304068686545aa368b35dfda1cdfbbdbe2f6fe43de4a2e9baa8ebd71be46e2"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:17e01dd8666c445025c29684d4aabf5a90dc6ef1ab25328aa52bedaa95b65ad7"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ea76dbcad0b7b0deb265d8c36e0801abcddf6cc1395940a24e3595288b405ca0"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:50a6adc2be8edd7ee67d1abc3cd20678987c7b9d79cd265de55941e3d0d56499"},
-    {file = "coverage-7.0.5-cp38-cp38-win32.whl", hash = "sha256:e4ce984133b888cc3a46867c8b4372c7dee9cee300335e2925e197bcd45b9e16"},
-    {file = "coverage-7.0.5-cp38-cp38-win_amd64.whl", hash = "sha256:4a950f83fd3f9bca23b77442f3a2b2ea4ac900944d8af9993743774c4fdc57af"},
-    {file = "coverage-7.0.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c2155943896ac78b9b0fd910fb381186d0c345911f5333ee46ac44c8f0e43ab"},
-    {file = "coverage-7.0.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:54f7e9705e14b2c9f6abdeb127c390f679f6dbe64ba732788d3015f7f76ef637"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ee30375b409d9a7ea0f30c50645d436b6f5dfee254edffd27e45a980ad2c7f4"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b78729038abea6a5df0d2708dce21e82073463b2d79d10884d7d591e0f385ded"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13250b1f0bd023e0c9f11838bdeb60214dd5b6aaf8e8d2f110c7e232a1bff83b"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2c407b1950b2d2ffa091f4e225ca19a66a9bd81222f27c56bd12658fc5ca1209"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:c76a3075e96b9c9ff00df8b5f7f560f5634dffd1658bafb79eb2682867e94f78"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f26648e1b3b03b6022b48a9b910d0ae209e2d51f50441db5dce5b530fad6d9b1"},
-    {file = "coverage-7.0.5-cp39-cp39-win32.whl", hash = "sha256:ba3027deb7abf02859aca49c865ece538aee56dcb4871b4cced23ba4d5088904"},
-    {file = "coverage-7.0.5-cp39-cp39-win_amd64.whl", hash = "sha256:949844af60ee96a376aac1ded2a27e134b8c8d35cc006a52903fc06c24a3296f"},
-    {file = "coverage-7.0.5-pp37.pp38.pp39-none-any.whl", hash = "sha256:b9727ac4f5cf2cbf87880a63870b5b9730a8ae3a4a360241a0fdaa2f71240ff0"},
-    {file = "coverage-7.0.5.tar.gz", hash = "sha256:051afcbd6d2ac39298d62d340f94dbb6a1f31de06dfaf6fcef7b759dd3860c45"},
+    {file = "coverage-7.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3b946bbcd5a8231383450b195cfb58cb01cbe7f8949f5758566b881df4b33baf"},
+    {file = "coverage-7.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ec8e767f13be637d056f7e07e61d089e555f719b387a7070154ad80a0ff31801"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4a5a5879a939cb84959d86869132b00176197ca561c664fc21478c1eee60d75"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b643cb30821e7570c0aaf54feaf0bfb630b79059f85741843e9dc23f33aaca2c"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32df215215f3af2c1617a55dbdfb403b772d463d54d219985ac7cd3bf124cada"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:33d1ae9d4079e05ac4cc1ef9e20c648f5afabf1a92adfaf2ccf509c50b85717f"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:29571503c37f2ef2138a306d23e7270687c0efb9cab4bd8038d609b5c2393a3a"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:63ffd21aa133ff48c4dff7adcc46b7ec8b565491bfc371212122dd999812ea1c"},
+    {file = "coverage-7.1.0-cp310-cp310-win32.whl", hash = "sha256:4b14d5e09c656de5038a3f9bfe5228f53439282abcab87317c9f7f1acb280352"},
+    {file = "coverage-7.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:8361be1c2c073919500b6601220a6f2f98ea0b6d2fec5014c1d9cfa23dd07038"},
+    {file = "coverage-7.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:da9b41d4539eefd408c46725fb76ecba3a50a3367cafb7dea5f250d0653c1040"},
+    {file = "coverage-7.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5b15ed7644ae4bee0ecf74fee95808dcc34ba6ace87e8dfbf5cb0dc20eab45a"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d12d076582507ea460ea2a89a8c85cb558f83406c8a41dd641d7be9a32e1274f"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2617759031dae1bf183c16cef8fcfb3de7617f394c813fa5e8e46e9b82d4222"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4e4881fa9e9667afcc742f0c244d9364d197490fbc91d12ac3b5de0bf2df146"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:9d58885215094ab4a86a6aef044e42994a2bd76a446dc59b352622655ba6621b"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ffeeb38ee4a80a30a6877c5c4c359e5498eec095878f1581453202bfacc8fbc2"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3baf5f126f30781b5e93dbefcc8271cb2491647f8283f20ac54d12161dff080e"},
+    {file = "coverage-7.1.0-cp311-cp311-win32.whl", hash = "sha256:ded59300d6330be27bc6cf0b74b89ada58069ced87c48eaf9344e5e84b0072f7"},
+    {file = "coverage-7.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:6a43c7823cd7427b4ed763aa7fb63901ca8288591323b58c9cd6ec31ad910f3c"},
+    {file = "coverage-7.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7a726d742816cb3a8973c8c9a97539c734b3a309345236cd533c4883dda05b8d"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc7c85a150501286f8b56bd8ed3aa4093f4b88fb68c0843d21ff9656f0009d6a"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5b4198d85a3755d27e64c52f8c95d6333119e49fd001ae5798dac872c95e0f8"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ddb726cb861c3117a553f940372a495fe1078249ff5f8a5478c0576c7be12050"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:51b236e764840a6df0661b67e50697aaa0e7d4124ca95e5058fa3d7cbc240b7c"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:7ee5c9bb51695f80878faaa5598040dd6c9e172ddcf490382e8aedb8ec3fec8d"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c31b75ae466c053a98bf26843563b3b3517b8f37da4d47b1c582fdc703112bc3"},
+    {file = "coverage-7.1.0-cp37-cp37m-win32.whl", hash = "sha256:3b155caf3760408d1cb903b21e6a97ad4e2bdad43cbc265e3ce0afb8e0057e73"},
+    {file = "coverage-7.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2a60d6513781e87047c3e630b33b4d1e89f39836dac6e069ffee28c4786715f5"},
+    {file = "coverage-7.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f2cba5c6db29ce991029b5e4ac51eb36774458f0a3b8d3137241b32d1bb91f06"},
+    {file = "coverage-7.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:beeb129cacea34490ffd4d6153af70509aa3cda20fdda2ea1a2be870dfec8d52"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c45948f613d5d18c9ec5eaa203ce06a653334cf1bd47c783a12d0dd4fd9c851"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef382417db92ba23dfb5864a3fc9be27ea4894e86620d342a116b243ade5d35d"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c7c0d0827e853315c9bbd43c1162c006dd808dbbe297db7ae66cd17b07830f0"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e5cdbb5cafcedea04924568d990e20ce7f1945a1dd54b560f879ee2d57226912"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9817733f0d3ea91bea80de0f79ef971ae94f81ca52f9b66500c6a2fea8e4b4f8"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:218fe982371ac7387304153ecd51205f14e9d731b34fb0568181abaf7b443ba0"},
+    {file = "coverage-7.1.0-cp38-cp38-win32.whl", hash = "sha256:04481245ef966fbd24ae9b9e537ce899ae584d521dfbe78f89cad003c38ca2ab"},
+    {file = "coverage-7.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:8ae125d1134bf236acba8b83e74c603d1b30e207266121e76484562bc816344c"},
+    {file = "coverage-7.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2bf1d5f2084c3932b56b962a683074a3692bce7cabd3aa023c987a2a8e7612f6"},
+    {file = "coverage-7.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:98b85dd86514d889a2e3dd22ab3c18c9d0019e696478391d86708b805f4ea0fa"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38da2db80cc505a611938d8624801158e409928b136c8916cd2e203970dde4dc"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3164d31078fa9efe406e198aecd2a02d32a62fecbdef74f76dad6a46c7e48311"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db61a79c07331e88b9a9974815c075fbd812bc9dbc4dc44b366b5368a2936063"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9ccb092c9ede70b2517a57382a601619d20981f56f440eae7e4d7eaafd1d1d09"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:33ff26d0f6cc3ca8de13d14fde1ff8efe1456b53e3f0273e63cc8b3c84a063d8"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d47dd659a4ee952e90dc56c97d78132573dc5c7b09d61b416a9deef4ebe01a0c"},
+    {file = "coverage-7.1.0-cp39-cp39-win32.whl", hash = "sha256:d248cd4a92065a4d4543b8331660121b31c4148dd00a691bfb7a5cdc7483cfa4"},
+    {file = "coverage-7.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7ed681b0f8e8bcbbffa58ba26fcf5dbc8f79e7997595bf071ed5430d8c08d6f3"},
+    {file = "coverage-7.1.0-pp37.pp38.pp39-none-any.whl", hash = "sha256:755e89e32376c850f826c425ece2c35a4fc266c081490eb0a841e7c1cb0d3bda"},
+    {file = "coverage-7.1.0.tar.gz", hash = "sha256:10188fe543560ec4874f974b5305cd1a8bdcfa885ee00ea3a03733464c4ca265"},
 ]
 
 [package.dependencies]
@@ -332,19 +346,19 @@ files = [
 
 [[package]]
 name = "isort"
-version = "5.11.4"
+version = "5.12.0"
 description = "A Python utility / library to sort Python imports."
 category = "dev"
 optional = false
-python-versions = ">=3.7.0"
+python-versions = ">=3.8.0"
 files = [
-    {file = "isort-5.11.4-py3-none-any.whl", hash = "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"},
-    {file = "isort-5.11.4.tar.gz", hash = "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6"},
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
 ]
 
 [package.extras]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
 plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
@@ -502,42 +516,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "0.991"
+version = "1.0.0"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "mypy-0.991-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab"},
-    {file = "mypy-0.991-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d"},
-    {file = "mypy-0.991-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6"},
-    {file = "mypy-0.991-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb"},
-    {file = "mypy-0.991-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305"},
-    {file = "mypy-0.991-cp310-cp310-win_amd64.whl", hash = "sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c"},
-    {file = "mypy-0.991-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372"},
-    {file = "mypy-0.991-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f"},
-    {file = "mypy-0.991-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33"},
-    {file = "mypy-0.991-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05"},
-    {file = "mypy-0.991-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad"},
-    {file = "mypy-0.991-cp311-cp311-win_amd64.whl", hash = "sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297"},
-    {file = "mypy-0.991-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813"},
-    {file = "mypy-0.991-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711"},
-    {file = "mypy-0.991-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd"},
-    {file = "mypy-0.991-cp37-cp37m-win_amd64.whl", hash = "sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef"},
-    {file = "mypy-0.991-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a"},
-    {file = "mypy-0.991-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93"},
-    {file = "mypy-0.991-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf"},
-    {file = "mypy-0.991-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135"},
-    {file = "mypy-0.991-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70"},
-    {file = "mypy-0.991-cp38-cp38-win_amd64.whl", hash = "sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243"},
-    {file = "mypy-0.991-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d"},
-    {file = "mypy-0.991-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5"},
-    {file = "mypy-0.991-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3"},
-    {file = "mypy-0.991-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648"},
-    {file = "mypy-0.991-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476"},
-    {file = "mypy-0.991-cp39-cp39-win_amd64.whl", hash = "sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461"},
-    {file = "mypy-0.991-py3-none-any.whl", hash = "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb"},
-    {file = "mypy-0.991.tar.gz", hash = "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06"},
+    {file = "mypy-1.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0626db16705ab9f7fa6c249c017c887baf20738ce7f9129da162bb3075fc1af"},
+    {file = "mypy-1.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1ace23f6bb4aec4604b86c4843276e8fa548d667dbbd0cb83a3ae14b18b2db6c"},
+    {file = "mypy-1.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87edfaf344c9401942883fad030909116aa77b0fa7e6e8e1c5407e14549afe9a"},
+    {file = "mypy-1.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0ab090d9240d6b4e99e1fa998c2d0aa5b29fc0fb06bd30e7ad6183c95fa07593"},
+    {file = "mypy-1.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:7cc2c01dfc5a3cbddfa6c13f530ef3b95292f926329929001d45e124342cd6b7"},
+    {file = "mypy-1.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:14d776869a3e6c89c17eb943100f7868f677703c8a4e00b3803918f86aafbc52"},
+    {file = "mypy-1.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bb2782a036d9eb6b5a6efcdda0986774bf798beef86a62da86cb73e2a10b423d"},
+    {file = "mypy-1.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cfca124f0ac6707747544c127880893ad72a656e136adc935c8600740b21ff5"},
+    {file = "mypy-1.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8845125d0b7c57838a10fd8925b0f5f709d0e08568ce587cc862aacce453e3dd"},
+    {file = "mypy-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b1b9e1ed40544ef486fa8ac022232ccc57109f379611633ede8e71630d07d2"},
+    {file = "mypy-1.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c7cf862aef988b5fbaa17764ad1d21b4831436701c7d2b653156a9497d92c83c"},
+    {file = "mypy-1.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cd187d92b6939617f1168a4fe68f68add749902c010e66fe574c165c742ed88"},
+    {file = "mypy-1.0.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:4e5175026618c178dfba6188228b845b64131034ab3ba52acaffa8f6c361f805"},
+    {file = "mypy-1.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2f6ac8c87e046dc18c7d1d7f6653a66787a4555085b056fe2d599f1f1a2a2d21"},
+    {file = "mypy-1.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7306edca1c6f1b5fa0bc9aa645e6ac8393014fa82d0fa180d0ebc990ebe15964"},
+    {file = "mypy-1.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3cfad08f16a9c6611e6143485a93de0e1e13f48cfb90bcad7d5fde1c0cec3d36"},
+    {file = "mypy-1.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67cced7f15654710386e5c10b96608f1ee3d5c94ca1da5a2aad5889793a824c1"},
+    {file = "mypy-1.0.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a86b794e8a56ada65c573183756eac8ac5b8d3d59daf9d5ebd72ecdbb7867a43"},
+    {file = "mypy-1.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:50979d5efff8d4135d9db293c6cb2c42260e70fb010cbc697b1311a4d7a39ddb"},
+    {file = "mypy-1.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3ae4c7a99e5153496243146a3baf33b9beff714464ca386b5f62daad601d87af"},
+    {file = "mypy-1.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5e398652d005a198a7f3c132426b33c6b85d98aa7dc852137a2a3be8890c4072"},
+    {file = "mypy-1.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be78077064d016bc1b639c2cbcc5be945b47b4261a4f4b7d8923f6c69c5c9457"},
+    {file = "mypy-1.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:92024447a339400ea00ac228369cd242e988dd775640755fa4ac0c126e49bb74"},
+    {file = "mypy-1.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:fe523fcbd52c05040c7bee370d66fee8373c5972171e4fbc323153433198592d"},
+    {file = "mypy-1.0.0-py3-none-any.whl", hash = "sha256:2efa963bdddb27cb4a0d42545cd137a8d2b883bd181bbc4525b568ef6eca258f"},
+    {file = "mypy-1.0.0.tar.gz", hash = "sha256:f34495079c8d9da05b183f9f7daec2878280c2ad7cc81da686ef0b484cea2ecf"},
 ]
 
 [package.dependencies]
@@ -553,52 +563,52 @@ reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 files = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 
 [[package]]
 name = "numpy"
-version = "1.24.1"
+version = "1.24.2"
 description = "Fundamental package for array computing in Python"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "numpy-1.24.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:179a7ef0889ab769cc03573b6217f54c8bd8e16cef80aad369e1e8185f994cd7"},
-    {file = "numpy-1.24.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b09804ff570b907da323b3d762e74432fb07955701b17b08ff1b5ebaa8cfe6a9"},
-    {file = "numpy-1.24.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1b739841821968798947d3afcefd386fa56da0caf97722a5de53e07c4ccedc7"},
-    {file = "numpy-1.24.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e3463e6ac25313462e04aea3fb8a0a30fb906d5d300f58b3bc2c23da6a15398"},
-    {file = "numpy-1.24.1-cp310-cp310-win32.whl", hash = "sha256:b31da69ed0c18be8b77bfce48d234e55d040793cebb25398e2a7d84199fbc7e2"},
-    {file = "numpy-1.24.1-cp310-cp310-win_amd64.whl", hash = "sha256:b07b40f5fb4fa034120a5796288f24c1fe0e0580bbfff99897ba6267af42def2"},
-    {file = "numpy-1.24.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7094891dcf79ccc6bc2a1f30428fa5edb1e6fb955411ffff3401fb4ea93780a8"},
-    {file = "numpy-1.24.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28e418681372520c992805bb723e29d69d6b7aa411065f48216d8329d02ba032"},
-    {file = "numpy-1.24.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e274f0f6c7efd0d577744f52032fdd24344f11c5ae668fe8d01aac0422611df1"},
-    {file = "numpy-1.24.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0044f7d944ee882400890f9ae955220d29b33d809a038923d88e4e01d652acd9"},
-    {file = "numpy-1.24.1-cp311-cp311-win32.whl", hash = "sha256:442feb5e5bada8408e8fcd43f3360b78683ff12a4444670a7d9e9824c1817d36"},
-    {file = "numpy-1.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:de92efa737875329b052982e37bd4371d52cabf469f83e7b8be9bb7752d67e51"},
-    {file = "numpy-1.24.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b162ac10ca38850510caf8ea33f89edcb7b0bb0dfa5592d59909419986b72407"},
-    {file = "numpy-1.24.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:26089487086f2648944f17adaa1a97ca6aee57f513ba5f1c0b7ebdabbe2b9954"},
-    {file = "numpy-1.24.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:caf65a396c0d1f9809596be2e444e3bd4190d86d5c1ce21f5fc4be60a3bc5b36"},
-    {file = "numpy-1.24.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0677a52f5d896e84414761531947c7a330d1adc07c3a4372262f25d84af7bf7"},
-    {file = "numpy-1.24.1-cp38-cp38-win32.whl", hash = "sha256:dae46bed2cb79a58d6496ff6d8da1e3b95ba09afeca2e277628171ca99b99db1"},
-    {file = "numpy-1.24.1-cp38-cp38-win_amd64.whl", hash = "sha256:6ec0c021cd9fe732e5bab6401adea5a409214ca5592cd92a114f7067febcba0c"},
-    {file = "numpy-1.24.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:28bc9750ae1f75264ee0f10561709b1462d450a4808cd97c013046073ae64ab6"},
-    {file = "numpy-1.24.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:84e789a085aabef2f36c0515f45e459f02f570c4b4c4c108ac1179c34d475ed7"},
-    {file = "numpy-1.24.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e669fbdcdd1e945691079c2cae335f3e3a56554e06bbd45d7609a6cf568c700"},
-    {file = "numpy-1.24.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef85cf1f693c88c1fd229ccd1055570cb41cdf4875873b7728b6301f12cd05bf"},
-    {file = "numpy-1.24.1-cp39-cp39-win32.whl", hash = "sha256:87a118968fba001b248aac90e502c0b13606721b1343cdaddbc6e552e8dfb56f"},
-    {file = "numpy-1.24.1-cp39-cp39-win_amd64.whl", hash = "sha256:ddc7ab52b322eb1e40521eb422c4e0a20716c271a306860979d450decbb51b8e"},
-    {file = "numpy-1.24.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ed5fb71d79e771ec930566fae9c02626b939e37271ec285e9efaf1b5d4370e7d"},
-    {file = "numpy-1.24.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad2925567f43643f51255220424c23d204024ed428afc5aad0f86f3ffc080086"},
-    {file = "numpy-1.24.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:cfa1161c6ac8f92dea03d625c2d0c05e084668f4a06568b77a25a89111621566"},
-    {file = "numpy-1.24.1.tar.gz", hash = "sha256:2386da9a471cc00a1f47845e27d916d5ec5346ae9696e01a8a34760858fe9dd2"},
+    {file = "numpy-1.24.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eef70b4fc1e872ebddc38cddacc87c19a3709c0e3e5d20bf3954c147b1dd941d"},
+    {file = "numpy-1.24.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8d2859428712785e8a8b7d2b3ef0a1d1565892367b32f915c4a4df44d0e64f5"},
+    {file = "numpy-1.24.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6524630f71631be2dabe0c541e7675db82651eb998496bbe16bc4f77f0772253"},
+    {file = "numpy-1.24.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a51725a815a6188c662fb66fb32077709a9ca38053f0274640293a14fdd22978"},
+    {file = "numpy-1.24.2-cp310-cp310-win32.whl", hash = "sha256:2620e8592136e073bd12ee4536149380695fbe9ebeae845b81237f986479ffc9"},
+    {file = "numpy-1.24.2-cp310-cp310-win_amd64.whl", hash = "sha256:97cf27e51fa078078c649a51d7ade3c92d9e709ba2bfb97493007103c741f1d0"},
+    {file = "numpy-1.24.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7de8fdde0003f4294655aa5d5f0a89c26b9f22c0a58790c38fae1ed392d44a5a"},
+    {file = "numpy-1.24.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4173bde9fa2a005c2c6e2ea8ac1618e2ed2c1c6ec8a7657237854d42094123a0"},
+    {file = "numpy-1.24.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cecaed30dc14123020f77b03601559fff3e6cd0c048f8b5289f4eeabb0eb281"},
+    {file = "numpy-1.24.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a23f8440561a633204a67fb44617ce2a299beecf3295f0d13c495518908e910"},
+    {file = "numpy-1.24.2-cp311-cp311-win32.whl", hash = "sha256:e428c4fbfa085f947b536706a2fc349245d7baa8334f0c5723c56a10595f9b95"},
+    {file = "numpy-1.24.2-cp311-cp311-win_amd64.whl", hash = "sha256:557d42778a6869c2162deb40ad82612645e21d79e11c1dc62c6e82a2220ffb04"},
+    {file = "numpy-1.24.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d0a2db9d20117bf523dde15858398e7c0858aadca7c0f088ac0d6edd360e9ad2"},
+    {file = "numpy-1.24.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c72a6b2f4af1adfe193f7beb91ddf708ff867a3f977ef2ec53c0ffb8283ab9f5"},
+    {file = "numpy-1.24.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c29e6bd0ec49a44d7690ecb623a8eac5ab8a923bce0bea6293953992edf3a76a"},
+    {file = "numpy-1.24.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2eabd64ddb96a1239791da78fa5f4e1693ae2dadc82a76bc76a14cbb2b966e96"},
+    {file = "numpy-1.24.2-cp38-cp38-win32.whl", hash = "sha256:e3ab5d32784e843fc0dd3ab6dcafc67ef806e6b6828dc6af2f689be0eb4d781d"},
+    {file = "numpy-1.24.2-cp38-cp38-win_amd64.whl", hash = "sha256:76807b4063f0002c8532cfeac47a3068a69561e9c8715efdad3c642eb27c0756"},
+    {file = "numpy-1.24.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a"},
+    {file = "numpy-1.24.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f"},
+    {file = "numpy-1.24.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb"},
+    {file = "numpy-1.24.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780"},
+    {file = "numpy-1.24.2-cp39-cp39-win32.whl", hash = "sha256:63e45511ee4d9d976637d11e6c9864eae50e12dc9598f531c035265991910468"},
+    {file = "numpy-1.24.2-cp39-cp39-win_amd64.whl", hash = "sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:92011118955724465fb6853def593cf397b4a1367495e0b59a7e69d40c4eb71d"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9006288bcf4895917d02583cf3411f98631275bc67cce355a7f39f8c14338fa"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:150947adbdfeceec4e5926d956a06865c1c690f2fd902efede4ca6fe2e657c3f"},
+    {file = "numpy-1.24.2.tar.gz", hash = "sha256:003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22"},
 ]
 
 [[package]]
@@ -627,14 +637,14 @@ files = [
 
 [[package]]
 name = "pathspec"
-version = "0.10.3"
+version = "0.11.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
-    {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
+    {file = "pathspec-0.11.0-py3-none-any.whl", hash = "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229"},
+    {file = "pathspec-0.11.0.tar.gz", hash = "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"},
 ]
 
 [[package]]
@@ -723,19 +733,19 @@ tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "pa
 
 [[package]]
 name = "platformdirs"
-version = "2.6.2"
+version = "3.0.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
-    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
+    {file = "platformdirs-3.0.0-py3-none-any.whl", hash = "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"},
+    {file = "platformdirs-3.0.0.tar.gz", hash = "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9"},
 ]
 
 [package.extras]
-docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -901,14 +911,14 @@ tokenize-rt = ">=3.2.0"
 
 [[package]]
 name = "setuptools"
-version = "66.1.1"
+version = "67.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
+    {file = "setuptools-67.2.0-py3-none-any.whl", hash = "sha256:16ccf598aab3b506593c17378473978908a2734d7336755a8769b480906bec1c"},
+    {file = "setuptools-67.2.0.tar.gz", hash = "sha256:b440ee5f7e607bb8c9de15259dba2583dd41a38879a7abc1d43a71c59524da48"},
 ]
 
 [package.extras]

--- a/tests/test_builtin_math.py
+++ b/tests/test_builtin_math.py
@@ -4,7 +4,7 @@ import pytest
 from typing import Tuple, Callable
 
 import timevec.builtin_math as tv
-from timevec.util import DateTimeRange
+import timevec.util as util
 
 
 def assert_vector_in_circle(x: float, y: float, *, abs: float = 1e-6) -> None:
@@ -41,7 +41,7 @@ def assert_vector_continuity(
 
 
 def assert_range_vector_value(
-    range: DateTimeRange,
+    range: util.DateTimeRange,
     fn: Callable[[datetime.datetime], Tuple[float, float]],
     *,
     abs: float = 1e-6,
@@ -87,19 +87,19 @@ def test_range_vector_special_values() -> None:
         datetime.datetime(5001, 1, 1, 0, 0, 0),
     ]
     for dt in many_dates:
-        range = tv.long_time_range(dt)
+        range = util.long_time_range(dt)
         assert_range_vector_value(range, tv.long_time_vec)
-        range = tv.millenium_range(dt)
+        range = util.millenium_range(dt)
         assert_range_vector_value(range, tv.millenium_vec)
-        range = tv.century_range(dt)
+        range = util.century_range(dt)
         assert_range_vector_value(range, tv.century_vec)
-        range = tv.year_range(dt)
+        range = util.year_range(dt)
         assert_range_vector_value(range, tv.year_vec)
-        range = tv.month_range(dt)
+        range = util.month_range(dt)
         assert_range_vector_value(range, tv.month_vec)
-        range = tv.week_range(dt)
+        range = util.week_range(dt)
         assert_range_vector_value(range, tv.week_vec)
-        range = tv.day_range(dt)
+        range = util.day_range(dt)
         assert_range_vector_value(range, tv.day_vec)
 
 
@@ -178,11 +178,3 @@ def test_edge_cases() -> None:
     dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
     x, y = tv.year_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
-
-
-def test_datetime_from_vec() -> None:
-    dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    yv = tv.year_vec(dt)
-    dv = tv.day_vec(dt)
-    dt2 = tv.datetime_from_vec(2023, yv, dv)
-    assert pytest.approx(dt, abs=1e-6) == dt2

--- a/tests/test_builtin_math.py
+++ b/tests/test_builtin_math.py
@@ -1,149 +1,199 @@
 import datetime
 
 import pytest
+from typing import Tuple, Callable
 
-from timevec.builtin_math import (
-    day_vec, month_vec, week_vec, year_vec,
-    datetime_from_vec, century_vec,
-    millenium_vec, long_time_vec,
-)
+import timevec.builtin_math as tv
+
+
+def assert_vector_in_circle(x: float, y: float, *, abs: float = 1e-6) -> None:
+    assert pytest.approx(x**2 + y**2, abs=abs) == 1.0
+
+
+def assert_vector_continuity(
+    dt: datetime.datetime,
+    fn: Callable[[datetime.datetime], Tuple[float, float]],
+    eps_timedelta: datetime.timedelta = datetime.timedelta(seconds=0.01),
+) -> None:
+    """Test that the vector is continuous and in the same basis"""
+    # all vectors must be same length in polar coordinates
+    x1, y1 = fn(dt)
+    assert_vector_in_circle(x1, y1)
+
+    # Add small tim delta means that very small rotation
+    x2, y2 = fn(dt + eps_timedelta)
+    assert_vector_in_circle(x2, y2)
+    # The angle between vectors must be very small
+    cos_similarity1 = abs(x1 * x2 + y1 * y2)  # cos(angle)
+    assert cos_similarity1 > 0.9999
+
+    # rotate to reverse direction
+    x3, y3 = fn(dt + 2 * eps_timedelta)
+    assert_vector_in_circle(x3, y3)
+    cos_similarity2 = abs(x2 * x3 + y2 * y3)  # cos(angle)
+    assert cos_similarity2 > 0.9999
+
+    assert cos_similarity1 == pytest.approx(cos_similarity2)
+    # The vectors must be in the same basis
+    assert (x1 + x2 + x3) / 3 == pytest.approx(x2, abs=1e-6)
+    assert (y1 + y2 + y3) / 3 == pytest.approx(y2, abs=1e-6)
+
+
+def test_basis() -> None:
+    # Test that all the functions are consistent with each other
+    # and that they are all in the same basis
+    many_dates = [
+        datetime.datetime(100, 1, 1, 0, 0, 0),
+        datetime.datetime(2001, 1, 1, 0, 0, 0),
+        datetime.datetime(2023, 1, 1, 0, 0, 0),
+        datetime.datetime(2023, 2, 1, 0, 0, 0),
+        datetime.datetime(5001, 1, 1, 0, 0, 0),
+    ]
+    for dt in many_dates:
+        assert_vector_continuity(dt, tv.long_time_vec)
+        assert_vector_continuity(dt, tv.millenium_vec)
+        assert_vector_continuity(dt, tv.century_vec)
+        assert_vector_continuity(dt, tv.year_vec)
+        assert_vector_continuity(dt, tv.month_vec)
+        assert_vector_continuity(dt, tv.week_vec)
+        assert_vector_continuity(dt, tv.day_vec)
 
 
 def test_long_time_vec() -> None:
     # 0 degrees at the beginning of the long time
     dt = datetime.datetime(1, 1, 1, 0, 0, 0)
-    x, y = long_time_vec(dt)
+    x, y = tv.long_time_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
 
 def test_millenium_vec() -> None:
     # 0 degrees at the beginning of the millenium
     dt = datetime.datetime(2001, 1, 1, 0, 0, 0)
-    x, y = millenium_vec(dt)
+    x, y = tv.millenium_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
 
 def test_century_vec() -> None:
     # 0 degrees at the beginning of the century
     dt = datetime.datetime(2001, 1, 1, 0, 0, 0)
-    x, y = century_vec(dt)
+    x, y = tv.century_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
 
 def test_year_vec() -> None:
     # 0 degrees at the beginning of the year
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    x, y = year_vec(dt)
+    x, y = tv.year_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
     # 180 degrees at the middle of the year
     dt = datetime.datetime(2023, 7, 2, 12, 0, 0)
-    x, y = year_vec(dt)
+    x, y = tv.year_vec(dt)
     assert (x, y) == pytest.approx((-1.0, 0.0), abs=1e-6)
 
     # 360 degrees at the end of the year
     dt = datetime.datetime(2023, 12, 31, 23, 59, 59)
-    x, y = year_vec(dt)
+    x, y = tv.year_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
 
 def test_month_vec() -> None:
     # 0 degrees at the beginning of the month
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    x, y = month_vec(dt)
+    x, y = tv.month_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
     # 180 degrees at the middle of the month
     dt = datetime.datetime(2023, 1, 16, 12, 0, 0)
-    x, y = month_vec(dt)
+    x, y = tv.month_vec(dt)
     assert (x, y) == pytest.approx((-1.0, 0.0), abs=1e-6)
 
     # 360 degrees at the end of the month
     dt = datetime.datetime(2023, 1, 31, 23, 59, 59)
-    x, y = month_vec(dt)
+    x, y = tv.month_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-5)
 
 
 def test_week_vec() -> None:
     # 0 degrees at the beginning of the week
     dt = datetime.datetime(2023, 1, 2, 0, 0, 0)  # Monday
-    x, y = week_vec(dt)
+    x, y = tv.week_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 3, 0, 0, 0)  # Tuesday
-    x, y = week_vec(dt)
+    x, y = tv.week_vec(dt)
     assert (x, y) == pytest.approx((0.623489, 0.781831), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 4, 0, 0, 0)  # Wednesday
-    x, y = week_vec(dt)
+    x, y = tv.week_vec(dt)
     assert (x, y) == pytest.approx((-0.222521, 0.974928), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 5, 0, 0, 0)  # Thursday
-    x, y = week_vec(dt)
+    x, y = tv.week_vec(dt)
     assert (x, y) == pytest.approx((-0.900969, 0.433884), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 6, 0, 0, 0)  # Friday
-    x, y = week_vec(dt)
+    x, y = tv.week_vec(dt)
     assert (x, y) == pytest.approx((-0.900969, -0.433884), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 7, 0, 0, 0)  # Saturday
-    x, y = week_vec(dt)
+    x, y = tv.week_vec(dt)
     assert (x, y) == pytest.approx((-0.222521, -0.974928), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 8, 0, 0, 0)  # Sunday
-    x, y = week_vec(dt)
+    x, y = tv.week_vec(dt)
     assert (x, y) == pytest.approx((0.623489, -0.781831), abs=1e-6)
 
     # next monday
     dt = datetime.datetime(2023, 1, 9, 0, 0, 0)
-    x, y = week_vec(dt)
+    x, y = tv.week_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
 
 def test_day_vec() -> None:
     # 0 degrees at the beginning of the day
     dt = datetime.datetime(2023, 1, 2, 0, 0, 0)
-    x, y = day_vec(dt)
+    x, y = tv.day_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
     # 180 degrees at the middle of the day
     dt = datetime.datetime(2023, 1, 2, 12, 0, 0)
-    x, y = day_vec(dt)
+    x, y = tv.day_vec(dt)
     assert (x, y) == pytest.approx((-1.0, 0.0), abs=1e-6)
 
     # 360 degrees at the almost end of the day
     dt = datetime.datetime(2023, 1, 2, 23, 59, 59, 999999)
-    x, y = day_vec(dt)
+    x, y = tv.day_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
 
 def test_edge_cases() -> None:
     # beginning of year
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    x, y = year_vec(dt)
+    x, y = tv.year_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    x, y = month_vec(dt)
+    x, y = tv.month_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 2, 0, 0, 0)
-    x, y = week_vec(dt)
+    x, y = tv.week_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 2, 0, 0, 0)
-    x, y = day_vec(dt)
+    x, y = tv.day_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
     # end of year
     dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
-    x, y = year_vec(dt)
+    x, y = tv.year_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
 
 
 def test_datetime_from_vec() -> None:
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    yv = year_vec(dt)
-    dv = day_vec(dt)
-    dt2 = datetime_from_vec(2023, yv, dv)
+    yv = tv.year_vec(dt)
+    dv = tv.day_vec(dt)
+    dt2 = tv.datetime_from_vec(2023, yv, dv)
     assert pytest.approx(dt, abs=1e-6) == dt2

--- a/tests/test_many_dates.py
+++ b/tests/test_many_dates.py
@@ -9,37 +9,36 @@ import pytest
 
 def test_many_dates() -> None:
     # start 1-01-01
-    dt = datetime.datetime(1, 1, 1, 0, 0, 0)
+    dt = datetime.datetime(11, 1, 1, 0, 0, 0)
+    full = ['long_time', 'millenium', 'century', 'decade', 'year', 'month', 'week', 'day']
+    minimal = ['long_time', 'century', 'year', 'day']
+
 
     # try all the functions does not raise an exception
     for i in range(50000):
         dt += datetime.timedelta(days=17, hours=13, minutes=11, seconds=7)
-        tv.long_time_range(dt)
-        tv.millenium_vec(dt)
-        tv.century_vec(dt)
-        yv = tv.year_vec(dt)
-        tv.month_vec(dt)
-        tv.week_vec(dt)
-        dv = tv.day_vec(dt)
-        assert pytest.approx(dt) == tv.datetime_from_vec(dt.year, yv, dv)
 
-        tvn.long_time_range(dt)
-        tvn.millenium_vec(dt)
-        tvn.century_vec(dt)
-        yvn = tvn.year_vec(dt)
-        tvn.month_vec(dt)
-        tvn.week_vec(dt)
-        dvn = tvn.day_vec(dt)
-        assert pytest.approx(dt) == tvn.datetime_from_vec(dt.year, yvn, dvn)
+        vecs2 = tv.datetime_to_vecs(dt, full)
+        dt2 = tv.datetime_from_vecs(vecs2)
+        assert dt == dt2
 
-        tv64.long_time_range(np.datetime64(dt))
-        tv64.millenium_vec(np.datetime64(dt))
-        tv64.century_vec(np.datetime64(dt))
-        yv64 = tv64.year_vec(np.datetime64(dt))
-        tv64.month_vec(np.datetime64(dt))
-        tv64.week_vec(np.datetime64(dt))
-        dv64 = tv64.day_vec(np.datetime64(dt))
-        assert pytest.approx(np.datetime64(dt)) == tv64.datetime64_from_vec(dt.year, yv64, dv64)
+        vecs3 = tv.datetime_to_vecs(dt, minimal)
+        dt3 = tv.datetime_from_vecs(vecs3)
+        assert dt == dt3
+
+        vecs4 = tvn.datetime_to_vecs(dt, full)
+        dt4 = tvn.datetime_from_vecs(vecs4)
+        assert dt == dt4
+
+        vecs5 = tvn.datetime_to_vecs(dt, minimal)
+        dt5 = tvn.datetime_from_vecs(vecs5)
+        assert dt == dt5
+
+        vecs6 = tv64.datetime64_to_vecs(np.datetime64(dt), full)
+        tv64.datetime64_from_vecs(vecs6)
+
+        vecs7 = tv64.datetime64_to_vecs(np.datetime64(dt), minimal)
+        tv64.datetime64_from_vecs(vecs7)
 
     # tested up to 2100-01-01
     assert dt >= datetime.datetime(2400, 1, 1, 0, 0, 0)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -3,139 +3,139 @@ import datetime
 import numpy as np
 import pytest
 
-from timevec.numpy import day_vec, month_vec, week_vec, year_vec, century_vec, long_time_vec, millenium_vec
+import timevec.numpy as tvn
 
 
 def test_long_time_vec() -> None:
     dt = datetime.datetime(1, 1, 1, 0, 0, 0)
-    vec = long_time_vec(dt)
+    vec = tvn.long_time_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(5001, 1, 1, 0, 0, 0)
-    vec = long_time_vec(dt)
+    vec = tvn.long_time_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
 
 def test_millenium_vec() -> None:
     dt = datetime.datetime(2001, 1, 1, 0, 0, 0)
-    vec = millenium_vec(dt)
+    vec = tvn.millenium_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(3001, 1, 1, 0, 0, 0)
-    vec = millenium_vec(dt)
+    vec = tvn.millenium_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
 
 def test_century_vec() -> None:
     dt = datetime.datetime(2001, 1, 1, 0, 0, 0)
-    vec = century_vec(dt)
+    vec = tvn.century_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2051, 1, 1, 0, 0, 0)
-    vec = century_vec(dt)
+    vec = tvn.century_vec(dt)
     assert vec == pytest.approx(np.array([-1.0, 0.0]), abs=1e-6)
 
 
 def test_year_vec() -> None:
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    vec = year_vec(dt)
+    vec = tvn.year_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2023, 7, 2, 12, 0, 0)
-    vec = year_vec(dt)
+    vec = tvn.year_vec(dt)
     assert vec == pytest.approx(np.array([-1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2023, 12, 31, 23, 59, 59)
-    vec = year_vec(dt)
+    vec = tvn.year_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
 
 def test_month_vec() -> None:
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    vec = month_vec(dt)
+    vec = tvn.month_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 16, 12, 0, 0)
-    vec = month_vec(dt)
+    vec = tvn.month_vec(dt)
     assert vec == pytest.approx(np.array([-1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 31, 23, 59, 59)
-    vec = month_vec(dt)
+    vec = tvn.month_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-5)
 
 
 def test_week_vec() -> None:
     dt = datetime.datetime(2023, 1, 2, 0, 0, 0)  # Monday
-    vec = week_vec(dt)
+    vec = tvn.week_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 3, 0, 0, 0)  # Tuesday
-    vec = week_vec(dt)
+    vec = tvn.week_vec(dt)
     assert vec == pytest.approx(np.array([0.623489, 0.781831]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 4, 0, 0, 0)  # Wednesday
-    vec = week_vec(dt)
+    vec = tvn.week_vec(dt)
     assert vec == pytest.approx(np.array([-0.222521, 0.974928]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 5, 0, 0, 0)  # Thursday
-    vec = week_vec(dt)
+    vec = tvn.week_vec(dt)
     assert vec == pytest.approx(np.array([-0.900969, 0.433884]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 6, 0, 0, 0)  # Friday
-    vec = week_vec(dt)
+    vec = tvn.week_vec(dt)
     assert vec == pytest.approx(np.array([-0.900969, -0.433884]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 7, 0, 0, 0)  # Saturday
-    vec = week_vec(dt)
+    vec = tvn.week_vec(dt)
     assert vec == pytest.approx(np.array([-0.222521, -0.974928]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 8, 0, 0, 0)  # Sunday
-    vec = week_vec(dt)
+    vec = tvn.week_vec(dt)
     assert vec == pytest.approx(np.array([0.623489, -0.781831]), abs=1e-6)
 
 
 def test_day_vec() -> None:
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    vec = day_vec(dt)
+    vec = tvn.day_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 1, 12, 0, 0)
-    vec = day_vec(dt)
+    vec = tvn.day_vec(dt)
     assert vec == pytest.approx(np.array([-1.0, 0.0]), abs=1e-6)
 
 
 def test_edge_cases() -> None:
     # beginning of year
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    vec = year_vec(dt)
+    vec = tvn.year_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    vec = month_vec(dt)
+    vec = tvn.month_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 2, 0, 0, 0)  # Monday
-    vec = week_vec(dt)
+    vec = tvn.week_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    vec = day_vec(dt)
+    vec = tvn.day_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     # end of year
     dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
-    vec = year_vec(dt)
+    vec = tvn.year_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
 
     dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
-    vec = month_vec(dt)
+    vec = tvn.month_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-5)
 
     dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
-    vec = day_vec(dt)
+    vec = tvn.day_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-4)
 
     # end of month
     dt = datetime.datetime(2023, 1, 31, 23, 59, 59, 999999)
-    vec = month_vec(dt)
+    vec = tvn.month_vec(dt)
     assert vec == pytest.approx(np.array([1.0, 0.0]), abs=1e-5)

--- a/tests/test_numpy_datetime64.py
+++ b/tests/test_numpy_datetime64.py
@@ -7,6 +7,18 @@ import timevec.numpy_datetime64 as tv64
 import timevec.numpy as tv
 
 
+def test_long_time_vec() -> None:
+    dt = datetime.datetime.now()
+    dt64 = np.datetime64(dt)
+    assert np.allclose(tv64.long_time_vec(dt64), tv.long_time_vec(dt))
+
+
+def test_millenium_vec() -> None:
+    dt = datetime.datetime.now()
+    dt64 = np.datetime64(dt)
+    assert np.allclose(tv64.millenium_vec(dt64), tv.millenium_vec(dt))
+
+
 def test_century_vec() -> None:
     dt = datetime.datetime.now()
     dt64 = np.datetime64(dt)

--- a/tests/test_same_result.py
+++ b/tests/test_same_result.py
@@ -21,6 +21,7 @@ def assert_same(
     rel_tol: float = 1e-9,
     abs_tol: float = 0.0,
 ) -> None:
+    """Assert that the functions return the same result."""
     dt = datetime.datetime(2020, 1, 1, 0, 0, 0)
     result1 = func1(dt)
     result2 = func2(dt)
@@ -30,6 +31,7 @@ def assert_same(
 
 
 def random_date() -> datetime.datetime:
+    """Return a random datetime between 1990-01-01 and 2030-12-31."""
     year = random.randint(1990, 2030)
     month = random.randint(1, 12)
     day = random.randint(1, 28)
@@ -40,16 +42,17 @@ def random_date() -> datetime.datetime:
 
 
 def random_dates(size: int = 2000) -> List[datetime.datetime]:
+    """Return a list of random datetimes."""
     dates = []
     for _ in range(size):
         dates.append(random_date())
     return dates
 
 
-def test_long_time_range() -> None:
+def test_long_time_vec() -> None:
     test_dates = random_dates()
     for dt in test_dates:
-        assert_same(dt, tv.long_time_range, tvn.long_time_range, tv64.long_time_range)
+        assert_same(dt, tv.long_time_vec, tvn.long_time_vec, tv64.long_time_vec)
 
 
 def test_millenium_vec() -> None:

--- a/tests/test_something.py
+++ b/tests/test_something.py
@@ -1,2 +1,0 @@
-def test_add() -> None:
-    assert 1 + 2 == 3

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,60 +8,94 @@ from timevec.util import (
     millenium_range,
     long_time_range,
     year_range,
+    DateTimeRange,
 )
+
+
+def assert_date_time_range(range: DateTimeRange) -> None:
+    """Assert that a DateTimeRange is valid"""
+    assert range.begin <= range.end
+    assert range.total_time == 2 * range.half_time == 4 * range.quarter_time
+    assert (
+        range.begin
+        < range.end_of_1st_quarter
+        < range.end_of_2nd_quarter
+        < range.end_of_3rd_quarter
+        < range.end
+    )
+
+
+def test_date_time_range() -> None:
+    """Test DateTimeRange"""
+    range = DateTimeRange(
+        datetime.datetime(2000, 1, 1), datetime.datetime(2000, 1, 2)
+    )
+    assert_date_time_range(range)
+    assert range.begin == datetime.datetime(2000, 1, 1)
+    assert range.end == datetime.datetime(2000, 1, 2)
+    assert range.total_time == datetime.timedelta(days=1)
 
 
 def test_long_time_range() -> None:
     """Test long_time_range()"""
-    begin, end = long_time_range(datetime.datetime(2000, 1, 1))
-    assert begin == datetime.datetime(1, 1, 1)
-    assert end == datetime.datetime(5001, 1, 1)
-    assert end - begin == datetime.timedelta(days=1826212)  # 5000 years contains 1212 leap years
+    range = long_time_range(datetime.datetime(2000, 1, 1))
+    assert_date_time_range(range)
+    assert range.begin == datetime.datetime(1, 1, 1)
+    assert range.end == datetime.datetime(5001, 1, 1)
+    assert range.total_time == datetime.timedelta(
+        days=1826212
+    )  # 5000 years contains 1212 leap years
 
 
 def test_millenium_range() -> None:
     """Test millenium_range()"""
-    begin, end = millenium_range(datetime.datetime(2000, 1, 1))
-    assert begin == datetime.datetime(1001, 1, 1)
-    assert end == datetime.datetime(2001, 1, 1)
-    assert end - begin == datetime.timedelta(days=365243)  # 1000 years contains 243 leap years
+    range = millenium_range(datetime.datetime(2000, 1, 1))
+    assert_date_time_range(range)
+    assert range.begin == datetime.datetime(1001, 1, 1)
+    assert range.end == datetime.datetime(2001, 1, 1)
+    assert range.total_time == datetime.timedelta(days=365243)
 
 
 def test_century_range() -> None:
     """Test century_range()"""
-    begin, end = century_range(datetime.datetime(2000, 1, 1))
-    assert begin == datetime.datetime(1901, 1, 1)
-    assert end == datetime.datetime(2001, 1, 1)
-    assert end - begin == datetime.timedelta(days=36525)
+    range = century_range(datetime.datetime(2000, 1, 1))
+    assert_date_time_range(range)
+    assert range.begin == datetime.datetime(1901, 1, 1)
+    assert range.end == datetime.datetime(2001, 1, 1)
+    assert range.total_time == datetime.timedelta(days=36525)
 
 
 def test_year_range() -> None:
     """Test year_range()"""
-    begin, end = year_range(datetime.datetime(2000, 1, 1))
-    assert begin == datetime.datetime(2000, 1, 1)
-    assert end == datetime.datetime(2001, 1, 1)
-    assert end - begin == datetime.timedelta(days=366)  # leap year
+    range = year_range(datetime.datetime(2000, 1, 1))
+    assert_date_time_range(range)
+    assert range.begin == datetime.datetime(2000, 1, 1)
+    assert range.end == datetime.datetime(2001, 1, 1)
+    assert range.total_time == datetime.timedelta(days=366)
 
 
 def test_month_range() -> None:
     """Test month_range()"""
-    begin, end = month_range(datetime.datetime(2000, 1, 1))
-    assert begin == datetime.datetime(2000, 1, 1)
-    assert end == datetime.datetime(2000, 2, 1)
-    assert end - begin == datetime.timedelta(days=31)
+    range = month_range(datetime.datetime(2000, 1, 1))
+    assert_date_time_range(range)
+    assert range.begin == datetime.datetime(2000, 1, 1)
+    assert range.end == datetime.datetime(2000, 2, 1)
+    assert range.total_time == datetime.timedelta(days=31)
 
 
 def test_week_range() -> None:
     """Test week_range()"""
-    begin, end = week_range(datetime.datetime(2000, 1, 1))
-    assert begin == datetime.datetime(1999, 12, 27)
-    assert end == datetime.datetime(2000, 1, 3)
-    assert end - begin == datetime.timedelta(days=7)
+    range = week_range(datetime.datetime(2000, 1, 1))
+    assert_date_time_range(range)
+    assert range.begin == datetime.datetime(1999, 12, 27)
+    assert range.end == datetime.datetime(2000, 1, 3)
+    assert range.total_time == datetime.timedelta(days=7)
 
 
 def test_day_range() -> None:
     """Test day_range()"""
-    begin, end = day_range(datetime.datetime(2000, 1, 1))
-    assert begin == datetime.datetime(2000, 1, 1, 0, 0, 0)
-    assert end == datetime.datetime(2000, 1, 2, 0, 0, 0)
-    assert end - begin == datetime.timedelta(days=1)
+    range = day_range(datetime.datetime(2000, 1, 1))
+    assert_date_time_range(range)
+    assert range.begin == datetime.datetime(2000, 1, 1)
+    assert range.end == datetime.datetime(2000, 1, 2)
+    assert range.total_time == datetime.timedelta(days=1)

--- a/timevec/builtin_math.py
+++ b/timevec/builtin_math.py
@@ -9,7 +9,6 @@ from timevec.util import (
     long_time_range,
     millenium_range,
     month_range,
-    time_elapsed_ratio,
     week_range,
     year_range,
 )
@@ -17,59 +16,51 @@ from timevec.util import (
 
 def long_time_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the long time as a vector"""
-    begin_of_long_time, end_of_long_time = long_time_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_long_time, end=end_of_long_time, current=dt
-    )
+    range = long_time_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def millenium_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the millenium as a vector"""
-    begin_of_millenium, end_of_millenium = millenium_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_millenium, end=end_of_millenium, current=dt
-    )
+    range = millenium_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def century_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the century as a vector"""
-    begin_of_century, end_of_century = century_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_century, end=end_of_century, current=dt
-    )
+    range = century_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def year_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the year as a vector"""
-    begin_of_year, end_of_year = year_range(dt)
-    rate = time_elapsed_ratio(begin=begin_of_year, end=end_of_year, current=dt)
+    range = year_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def month_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the month as a vector"""
-    begin_of_month, end_of_month = month_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_month, end=end_of_month, current=dt
-    )
+    range = month_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def week_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the week as a vector"""
     # weekday is 0 for Monday and 6 for Sunday
-    begin_of_week, end_of_week = week_range(dt)
-    rate = time_elapsed_ratio(begin=begin_of_week, end=end_of_week, current=dt)
+    range = week_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def day_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the day as a vector"""
-    begin_of_day, end_of_day = day_range(dt)
-    rate = time_elapsed_ratio(begin=begin_of_day, end=end_of_day, current=dt)
+    range = day_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 

--- a/timevec/builtin_math.py
+++ b/timevec/builtin_math.py
@@ -65,6 +65,7 @@ def day_vec(dt: datetime.datetime) -> Tuple[float, float]:
 
 
 def ratio_to_vec(rate: float) -> Tuple[float, float]:
+    """Convert a rate to a vector"""
     s = 2 * math.pi * rate
     x = math.cos(s)
     y = math.sin(s)
@@ -72,6 +73,7 @@ def ratio_to_vec(rate: float) -> Tuple[float, float]:
 
 
 def vec_to_ratio(x: float, y: float) -> float:
+    """Convert a vector to a rate"""
     # atan2 returns a value in the range [-pi, pi]
     # so we need to convert it to the range [0, 2*pi]
     angle = math.atan2(y, x) / (2.0 * math.pi)

--- a/timevec/builtin_math.py
+++ b/timevec/builtin_math.py
@@ -1,50 +1,48 @@
-import calendar
 import datetime
 import math
-from typing import Tuple
+from typing import Dict, Iterable, Tuple
 
-from timevec.util import (
-    century_range,
-    day_range,
-    long_time_range,
-    millenium_range,
-    month_range,
-    week_range,
-    year_range,
-)
+import timevec.util as util
 
 
 def long_time_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the long time as a vector"""
-    range = long_time_range(dt)
+    range = util.long_time_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def millenium_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the millenium as a vector"""
-    range = millenium_range(dt)
+    range = util.millenium_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def century_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the century as a vector"""
-    range = century_range(dt)
+    range = util.century_range(dt)
+    rate = range.time_elapsed_ratio(dt)
+    return ratio_to_vec(rate)
+
+
+def decade_vec(dt: datetime.datetime) -> Tuple[float, float]:
+    """Represent the elapsed time in the decade as a vector"""
+    range = util.decade_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def year_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the year as a vector"""
-    range = year_range(dt)
+    range = util.year_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def month_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the month as a vector"""
-    range = month_range(dt)
+    range = util.month_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
@@ -52,14 +50,14 @@ def month_vec(dt: datetime.datetime) -> Tuple[float, float]:
 def week_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the week as a vector"""
     # weekday is 0 for Monday and 6 for Sunday
-    range = week_range(dt)
+    range = util.week_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
 def day_vec(dt: datetime.datetime) -> Tuple[float, float]:
     """Represent the elapsed time in the day as a vector"""
-    range = day_range(dt)
+    range = util.day_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
@@ -80,15 +78,82 @@ def vec_to_ratio(x: float, y: float) -> float:
     return angle if angle >= 0 else angle + 1.0
 
 
-def datetime_from_vec(
-    year: int,
-    yv: Tuple[float, float],
-    dv: Tuple[float, float],
+def datetime_to_vecs(
+    dt: datetime.datetime,
+    targets: Iterable[util.TARGET],
+) -> Dict[util.TARGET, Tuple[float, float]]:
+    """Convert a datetime to a vector"""
+    d: Dict[util.TARGET, Tuple[float, float]] = {}
+    if "long_time" in targets:
+        d["long_time"] = long_time_vec(dt)
+    if "millenium" in targets:
+        d["millenium"] = millenium_vec(dt)
+    if "century" in targets:
+        d["century"] = century_vec(dt)
+    if "decade" in targets:
+        d["decade"] = decade_vec(dt)
+    if "year" in targets:
+        d["year"] = year_vec(dt)
+    if "month" in targets:
+        d["month"] = month_vec(dt)
+    if "week" in targets:
+        d["week"] = week_vec(dt)
+    if "day" in targets:
+        d["day"] = day_vec(dt)
+    return d
+
+
+def datetime_from_vecs(
+    items: Dict[util.TARGET, Tuple[float, float]],
 ) -> datetime.datetime:
-    position_in_year = vec_to_ratio(*yv)
-    position_in_day = vec_to_ratio(*dv)
-    d = int(position_in_year * (366.0 if calendar.isleap(year) else 365.0))
-    s = position_in_day * 86400.0
-    return datetime.datetime(year, 1, 1, 0, 0, 0, 0) + datetime.timedelta(
-        days=int(d), seconds=s
-    )
+    """Convert a vector to a datetime"""
+    # long time → millenium → century → decade → year → month → week → day
+    t = util.BEGIN_OF_DATETIME
+
+    if "long_time" in items:
+        range = util.long_time_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(*items["long_time"]))
+
+    if "millenium" in items:
+        range = util.millenium_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(*items["millenium"]))
+
+    if "century" in items:
+        range = util.century_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(*items["century"]))
+
+    if "decade" in items:
+        range = util.decade_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(*items["decade"]))
+
+    if "year" in items:
+        range = util.year_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(*items["year"]))
+
+    if "month" in items:
+        range = util.month_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(*items["month"]))
+
+    if "week" in items:
+        range = util.week_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(*items["week"]))
+
+    if "day" in items:
+        range = util.day_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(*items["day"]))
+
+    return t
+
+
+__all__ = [
+    "long_time_vec",
+    "millenium_vec",
+    "century_vec",
+    "decade_vec",
+    "year_vec",
+    "month_vec",
+    "week_vec",
+    "day_vec",
+    "datetime_to_vecs",
+    "datetime_from_vecs",
+]

--- a/timevec/numpy.py
+++ b/timevec/numpy.py
@@ -10,7 +10,6 @@ from timevec.util import (
     long_time_range,
     millenium_range,
     month_range,
-    time_elapsed_ratio,
     week_range,
     year_range,
 )
@@ -20,12 +19,8 @@ def long_time_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the long time as a vector"""
-    begin_of_long_time, end_of_long_time = long_time_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_long_time,
-        end=end_of_long_time,
-        current=dt,
-    )
+    range = long_time_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -33,12 +28,8 @@ def millenium_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the millenium as a vector"""
-    begin_of_millenium, end_of_millenium = millenium_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_millenium,
-        end=end_of_millenium,
-        current=dt,
-    )
+    range = millenium_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -46,12 +37,8 @@ def century_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the century as a vector"""
-    begin_of_century, end_of_century = century_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_century,
-        end=end_of_century,
-        current=dt,
-    )
+    range = century_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -59,12 +46,8 @@ def year_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the year as a vector"""
-    begin_of_year, end_of_year = year_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_year,
-        end=end_of_year,
-        current=dt,
-    )
+    range = year_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -72,12 +55,8 @@ def month_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the month as a vector"""
-    begin_of_month, end_of_month = month_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_month,
-        end=end_of_month,
-        current=dt,
-    )
+    range = month_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -85,12 +64,8 @@ def week_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the week as a vector"""
-    begin_of_week, end_of_week = week_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_week,
-        end=end_of_week,
-        current=dt,
-    )
+    range = week_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -98,12 +73,8 @@ def day_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the day as a vector"""
-    begin_of_day, end_of_day = day_range(dt)
-    rate = time_elapsed_ratio(
-        begin=begin_of_day,
-        end=end_of_day,
-        current=dt,
-    )
+    range = day_range(dt)
+    rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
 

--- a/timevec/numpy.py
+++ b/timevec/numpy.py
@@ -1,25 +1,30 @@
-import calendar
 import datetime
+from typing import Dict, Iterable
 
 import numpy as np
 import numpy.typing as npt
 
-from timevec.util import (
-    century_range,
-    day_range,
-    long_time_range,
-    millenium_range,
-    month_range,
-    week_range,
-    year_range,
-)
+import timevec.util as util
+
+# from timevec.util import (
+#     BEGIN_OF_DATETIME,
+#     TARGET,
+#     century_range,
+#     day_range,
+#     decade_range,
+#     long_time_range,
+#     millenium_range,
+#     month_range,
+#     week_range,
+#     year_range,
+# )
 
 
 def long_time_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the long time as a vector"""
-    range = long_time_range(dt)
+    range = util.long_time_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
@@ -28,7 +33,7 @@ def millenium_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the millenium as a vector"""
-    range = millenium_range(dt)
+    range = util.millenium_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
@@ -37,7 +42,16 @@ def century_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the century as a vector"""
-    range = century_range(dt)
+    range = util.century_range(dt)
+    rate = range.time_elapsed_ratio(dt)
+    return ratio_to_vec(rate, dtype=dtype)
+
+
+def decade_vec(
+    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
+) -> npt.NDArray:
+    """Represent the elapsed time in the decade as a vector"""
+    range = util.decade_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
@@ -46,7 +60,7 @@ def year_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the year as a vector"""
-    range = year_range(dt)
+    range = util.year_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
@@ -55,7 +69,7 @@ def month_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the month as a vector"""
-    range = month_range(dt)
+    range = util.month_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
@@ -64,7 +78,7 @@ def week_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the week as a vector"""
-    range = week_range(dt)
+    range = util.week_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
@@ -73,7 +87,7 @@ def day_vec(
     dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
 ) -> npt.NDArray:
     """Represent the elapsed time in the day as a vector"""
-    range = day_range(dt)
+    range = util.day_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate, dtype=dtype)
 
@@ -96,14 +110,83 @@ def vec_to_ratio(arr: npt.NDArray) -> float:
     return float(base if base >= 0.0 else base + 1.0)
 
 
-def datetime_from_vec(
-    year: int,
-    yv: npt.NDArray,
-    dv: npt.NDArray,
+def datetime_to_vecs(
+    dt: datetime.datetime,
+    targets: Iterable[util.TARGET],
+    *,
+    dtype: npt.DTypeLike = np.float64,
+) -> Dict[util.TARGET, npt.NDArray]:
+    """Convert a datetime to a vector"""
+    d: Dict[util.TARGET, npt.NDArray] = {}
+    if "long_time" in targets:
+        d["long_time"] = long_time_vec(dt, dtype=dtype)
+    if "millenium" in targets:
+        d["millenium"] = millenium_vec(dt, dtype=dtype)
+    if "century" in targets:
+        d["century"] = century_vec(dt, dtype=dtype)
+    if "decade" in targets:
+        d["decade"] = decade_vec(dt, dtype=dtype)
+    if "year" in targets:
+        d["year"] = year_vec(dt, dtype=dtype)
+    if "month" in targets:
+        d["month"] = month_vec(dt, dtype=dtype)
+    if "week" in targets:
+        d["week"] = week_vec(dt, dtype=dtype)
+    if "day" in targets:
+        d["day"] = day_vec(dt, dtype=dtype)
+    return d
+
+
+def datetime_from_vecs(
+    items: Dict[util.TARGET, npt.NDArray],
 ) -> datetime.datetime:
-    position_in_year = vec_to_ratio(yv)
-    position_in_day = vec_to_ratio(dv)
-    d = int(position_in_year * (366.0 if calendar.isleap(year) else 365.0))
-    s = position_in_day * 86400.0
-    delta = datetime.timedelta(days=d, seconds=s)
-    return datetime.datetime(year, 1, 1, 0, 0, 0, 0) + delta
+    """Convert a vector to a datetime"""
+    # long time → millenium → century → decade → year → month → week → day
+    t = util.BEGIN_OF_DATETIME
+
+    if "long_time" in items:
+        range = util.long_time_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(items["long_time"]))
+
+    if "millenium" in items:
+        range = util.millenium_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(items["millenium"]))
+
+    if "century" in items:
+        range = util.century_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(items["century"]))
+
+    if "decade" in items:
+        range = util.decade_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(items["decade"]))
+
+    if "year" in items:
+        range = util.year_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(items["year"]))
+
+    if "month" in items:
+        range = util.month_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(items["month"]))
+
+    if "week" in items:
+        range = util.week_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(items["week"]))
+
+    if "day" in items:
+        range = util.day_range(t)
+        t = range.current_time_by_ratio(vec_to_ratio(items["day"]))
+
+    return t
+
+
+__all__ = [
+    "century_vec",
+    "day_vec",
+    "long_time_vec",
+    "millenium_vec",
+    "month_vec",
+    "week_vec",
+    "year_vec",
+    "datetime_from_vecs",
+    "datetime_to_vecs",
+]

--- a/timevec/numpy_datetime64.py
+++ b/timevec/numpy_datetime64.py
@@ -10,7 +10,6 @@ from timevec.util import (
     long_time_range,
     millenium_range,
     month_range,
-    time_elapsed_ratio,
     week_range,
     year_range,
 )
@@ -21,12 +20,8 @@ def long_time_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the long time as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    begin_of_long_time, end_of_long_time = long_time_range(dt2)
-    rate = time_elapsed_ratio(
-        begin=begin_of_long_time,
-        end=end_of_long_time,
-        current=dt2,
-    )
+    range = long_time_range(dt2)
+    rate = range.time_elapsed_ratio(dt2)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -35,12 +30,8 @@ def millenium_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the millenium as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    begin_of_millenium, end_of_millenium = millenium_range(dt2)
-    rate = time_elapsed_ratio(
-        begin=begin_of_millenium,
-        end=end_of_millenium,
-        current=dt2,
-    )
+    range = millenium_range(dt2)
+    rate = range.time_elapsed_ratio(dt2)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -49,12 +40,8 @@ def century_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the century as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    begin_of_century, end_of_century = century_range(dt2)
-    rate = time_elapsed_ratio(
-        begin=begin_of_century,
-        end=end_of_century,
-        current=dt2,
-    )
+    range = century_range(dt2)
+    rate = range.time_elapsed_ratio(dt2)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -63,12 +50,8 @@ def year_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the year as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    begin_of_year, end_of_year = year_range(dt2)
-    rate = time_elapsed_ratio(
-        begin=begin_of_year,
-        end=end_of_year,
-        current=dt2,
-    )
+    range = year_range(dt2)
+    rate = range.time_elapsed_ratio(dt2)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -77,12 +60,8 @@ def month_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the month as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    begin_of_month, end_of_month = month_range(dt2)
-    rate = time_elapsed_ratio(
-        begin=begin_of_month,
-        end=end_of_month,
-        current=dt2,
-    )
+    range = month_range(dt2)
+    rate = range.time_elapsed_ratio(dt2)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -91,12 +70,8 @@ def week_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the week as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    begin_of_week, end_of_week = week_range(dt2)
-    rate = time_elapsed_ratio(
-        begin=begin_of_week,
-        end=end_of_week,
-        current=dt2,
-    )
+    range = week_range(dt2)
+    rate = range.time_elapsed_ratio(dt2)
     return ratio_to_vec(rate, dtype=dtype)
 
 
@@ -105,12 +80,8 @@ def day_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the day as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    begin_of_day, end_of_day = day_range(dt2)
-    rate = time_elapsed_ratio(
-        begin=begin_of_day,
-        end=end_of_day,
-        current=dt2,
-    )
+    range = day_range(dt2)
+    rate = range.time_elapsed_ratio(dt2)
     return ratio_to_vec(rate, dtype=dtype)
 
 

--- a/timevec/numpy_datetime64.py
+++ b/timevec/numpy_datetime64.py
@@ -1,18 +1,11 @@
 import datetime
+from typing import Dict, Iterable
 
 import numpy as np
 import numpy.typing as npt
 
-from timevec.numpy import datetime_from_vec, ratio_to_vec
-from timevec.util import (
-    century_range,
-    day_range,
-    long_time_range,
-    millenium_range,
-    month_range,
-    week_range,
-    year_range,
-)
+import timevec.numpy as tvn
+import timevec.util as util
 
 
 def long_time_vec(
@@ -20,9 +13,9 @@ def long_time_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the long time as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    range = long_time_range(dt2)
+    range = util.long_time_range(dt2)
     rate = range.time_elapsed_ratio(dt2)
-    return ratio_to_vec(rate, dtype=dtype)
+    return tvn.ratio_to_vec(rate, dtype=dtype)
 
 
 def millenium_vec(
@@ -30,9 +23,9 @@ def millenium_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the millenium as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    range = millenium_range(dt2)
+    range = util.millenium_range(dt2)
     rate = range.time_elapsed_ratio(dt2)
-    return ratio_to_vec(rate, dtype=dtype)
+    return tvn.ratio_to_vec(rate, dtype=dtype)
 
 
 def century_vec(
@@ -40,9 +33,9 @@ def century_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the century as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    range = century_range(dt2)
+    range = util.century_range(dt2)
     rate = range.time_elapsed_ratio(dt2)
-    return ratio_to_vec(rate, dtype=dtype)
+    return tvn.ratio_to_vec(rate, dtype=dtype)
 
 
 def year_vec(
@@ -50,9 +43,9 @@ def year_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the year as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    range = year_range(dt2)
+    range = util.year_range(dt2)
     rate = range.time_elapsed_ratio(dt2)
-    return ratio_to_vec(rate, dtype=dtype)
+    return tvn.ratio_to_vec(rate, dtype=dtype)
 
 
 def month_vec(
@@ -60,9 +53,9 @@ def month_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the month as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    range = month_range(dt2)
+    range = util.month_range(dt2)
     rate = range.time_elapsed_ratio(dt2)
-    return ratio_to_vec(rate, dtype=dtype)
+    return tvn.ratio_to_vec(rate, dtype=dtype)
 
 
 def week_vec(
@@ -70,9 +63,9 @@ def week_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the week as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    range = week_range(dt2)
+    range = util.week_range(dt2)
     rate = range.time_elapsed_ratio(dt2)
-    return ratio_to_vec(rate, dtype=dtype)
+    return tvn.ratio_to_vec(rate, dtype=dtype)
 
 
 def day_vec(
@@ -80,9 +73,9 @@ def day_vec(
 ) -> npt.NDArray:
     """Represent the elapsed time in the day as a vector"""
     dt2 = datetime64_to_datetime(dt)
-    range = day_range(dt2)
+    range = util.day_range(dt2)
     rate = range.time_elapsed_ratio(dt2)
-    return ratio_to_vec(rate, dtype=dtype)
+    return tvn.ratio_to_vec(rate, dtype=dtype)
 
 
 def datetime64_to_datetime(dt: np.datetime64) -> datetime.datetime:
@@ -94,11 +87,40 @@ def datetime64_to_datetime(dt: np.datetime64) -> datetime.datetime:
     return datetime.datetime.utcfromtimestamp(ts)
 
 
-def datetime64_from_vec(
-    year: int,
-    yv: npt.NDArray,
-    dv: npt.NDArray,
+def datetime_to_datetime64(dt: datetime.datetime) -> np.datetime64:
+    """Convert a datetime.datetime to a numpy.datetime64"""
+    ts = dt.timestamp()
+    dt64 = np.datetime64("1970-01-01T00:00:00") + np.timedelta64(int(ts), "s")
+    return dt64
+
+
+def datetime64_to_vecs(
+    dt: np.datetime64,
+    targets: Iterable[util.TARGET],
+    *,
+    dtype: npt.DTypeLike = np.float64
+) -> Dict[util.TARGET, npt.NDArray]:
+    """Convert a numpy.datetime64 to a vector"""
+    dt2 = datetime64_to_datetime(dt)
+    return tvn.datetime_to_vecs(dt2, targets, dtype=dtype)
+
+
+def datetime64_from_vecs(
+    items: Dict[util.TARGET, npt.NDArray]
 ) -> np.datetime64:
-    """Convert a vector representation of a datetime to a numpy.datetime64"""
-    dt = datetime_from_vec(year, yv, dv)
-    return np.datetime64(dt)
+    """Convert a vector to a numpy.datetime64"""
+    dt = tvn.datetime_from_vecs(items)
+    return datetime_to_datetime64(dt)
+
+
+__all__ = [
+    "century_vec",
+    "day_vec",
+    "long_time_vec",
+    "millenium_vec",
+    "month_vec",
+    "week_vec",
+    "year_vec",
+    "datetime64_from_vecs",
+    "datetime64_to_vecs",
+]

--- a/timevec/util.py
+++ b/timevec/util.py
@@ -45,6 +45,7 @@ class DateTimeRange:
 def long_time_range(
     dt: datetime.datetime,
 ) -> DateTimeRange:
+    """Return a DateTimeRange that covers a long time period"""
     begin = datetime.datetime.min.replace(
         year=1,
         month=1,
@@ -67,6 +68,7 @@ def long_time_range(
 def millenium_range(
     dt: datetime.datetime,
 ) -> DateTimeRange:
+    """Return a DateTimeRange that covers a millenium"""
     begin_of_millenium = datetime.datetime.min.replace(
         year=(dt.year - 1) // 1000 * 1000 + 1,
         month=1,
@@ -89,6 +91,7 @@ def millenium_range(
 def century_range(
     dt: datetime.datetime,
 ) -> DateTimeRange:
+    """Return a DateTimeRange that covers a century"""
     begin_of_century = datetime.datetime.min.replace(
         year=(dt.year - 1) // 100 * 100 + 1,
         month=1,
@@ -111,6 +114,7 @@ def century_range(
 def year_range(
     dt: datetime.datetime,
 ) -> DateTimeRange:
+    """Return a DateTimeRange that covers a year"""
     begin_of_year = datetime.datetime.min.replace(
         year=dt.year,
         month=1,
@@ -133,6 +137,7 @@ def year_range(
 def month_range(
     dt: datetime.datetime,
 ) -> DateTimeRange:
+    """Return a DateTimeRange that covers a month"""
     begin_of_month = datetime.datetime.min.replace(
         year=dt.year,
         month=dt.month,
@@ -156,6 +161,7 @@ def month_range(
 def week_range(
     dt: datetime.datetime,
 ) -> DateTimeRange:
+    """Return a DateTimeRange that covers a week"""
     begin_of_week = datetime.datetime.min.replace(
         year=dt.year,
         month=dt.month,
@@ -178,6 +184,7 @@ def week_range(
 def day_range(
     dt: datetime.datetime,
 ) -> DateTimeRange:
+    """Return a DateTimeRange that covers a day"""
     begin_of_day = datetime.datetime.min.replace(
         year=dt.year,
         month=dt.month,

--- a/timevec/util.py
+++ b/timevec/util.py
@@ -1,6 +1,18 @@
 import calendar
 import datetime
 from dataclasses import dataclass
+from typing import Literal
+
+TARGET = Literal[
+    "long_time",
+    "millenium",
+    "century",
+    "decade",
+    "year",
+    "month",
+    "week",
+    "day",
+]
 
 
 @dataclass
@@ -23,6 +35,18 @@ class DateTimeRange:
     def elapsed_time(self, current: datetime.datetime) -> datetime.timedelta:
         return current - self.begin
 
+    def elapsed_time_by_ratio(
+        self,
+        ratio: float,
+    ) -> datetime.timedelta:
+        return ratio * self.total_time
+
+    def current_time_by_ratio(
+        self,
+        ratio: float,
+    ) -> datetime.datetime:
+        return self.begin + self.elapsed_time_by_ratio(ratio)
+
     def time_elapsed_ratio(self, current: datetime.datetime) -> float:
         return (
             self.elapsed_time(current).total_seconds()
@@ -42,27 +66,18 @@ class DateTimeRange:
         return self.begin + 3 * self.quarter_time
 
 
+BEGIN_OF_DATETIME = datetime.datetime(1, 1, 1, 0, 0, 0)
+END_OF_DATETIME = datetime.datetime(5001, 1, 1, 0, 0, 0)
+
+
 def long_time_range(
     dt: datetime.datetime,
 ) -> DateTimeRange:
     """Return a DateTimeRange that covers a long time period"""
-    begin = datetime.datetime.min.replace(
-        year=1,
-        month=1,
-        day=1,
-        hour=0,
-        minute=0,
-        second=0,
+    return DateTimeRange(
+        begin=BEGIN_OF_DATETIME,
+        end=END_OF_DATETIME,
     )
-    end = datetime.datetime.min.replace(
-        year=5001,
-        month=1,
-        day=1,
-        hour=0,
-        minute=0,
-        second=0,
-    )
-    return DateTimeRange(begin, end)
 
 
 def millenium_range(
@@ -109,6 +124,29 @@ def century_range(
         second=0,
     )
     return DateTimeRange(begin_of_century, end_of_century)
+
+
+def decade_range(
+    dt: datetime.datetime,
+) -> DateTimeRange:
+    """Return a DateTimeRange that covers a decade"""
+    begin_of_decade = datetime.datetime.min.replace(
+        year=dt.year // 10 * 10,
+        month=1,
+        day=1,
+        hour=0,
+        minute=0,
+        second=0,
+    )
+    end_of_decade = datetime.datetime.min.replace(
+        year=dt.year // 10 * 10 + 10,
+        month=1,
+        day=1,
+        hour=0,
+        minute=0,
+        second=0,
+    )
+    return DateTimeRange(begin_of_decade, end_of_decade)
 
 
 def year_range(
@@ -202,3 +240,16 @@ def day_range(
         second=0,
     ) + datetime.timedelta(days=1)
     return DateTimeRange(begin_of_day, end_of_day)
+
+
+__all__ = [
+    "DateTimeRange",
+    "long_time_range",
+    "millenium_range",
+    "century_range",
+    "decade_range",
+    "year_range",
+    "month_range",
+    "week_range",
+    "day_range",
+]

--- a/timevec/util.py
+++ b/timevec/util.py
@@ -1,11 +1,50 @@
 import calendar
 import datetime
-from typing import Tuple
+from dataclasses import dataclass
+
+
+@dataclass
+class DateTimeRange:
+    begin: datetime.datetime
+    end: datetime.datetime
+
+    @property
+    def total_time(self) -> datetime.timedelta:
+        return self.end - self.begin
+
+    @property
+    def half_time(self) -> datetime.timedelta:
+        return self.total_time / 2
+
+    @property
+    def quarter_time(self) -> datetime.timedelta:
+        return self.total_time / 4
+
+    def elapsed_time(self, current: datetime.datetime) -> datetime.timedelta:
+        return current - self.begin
+
+    def time_elapsed_ratio(self, current: datetime.datetime) -> float:
+        return (
+            self.elapsed_time(current).total_seconds()
+            / self.total_time.total_seconds()
+        )
+
+    @property
+    def end_of_1st_quarter(self) -> datetime.datetime:
+        return self.begin + 1 * self.quarter_time
+
+    @property
+    def end_of_2nd_quarter(self) -> datetime.datetime:
+        return self.begin + 2 * self.quarter_time
+
+    @property
+    def end_of_3rd_quarter(self) -> datetime.datetime:
+        return self.begin + 3 * self.quarter_time
 
 
 def long_time_range(
     dt: datetime.datetime,
-) -> Tuple[datetime.datetime, datetime.datetime]:
+) -> DateTimeRange:
     begin = datetime.datetime.min.replace(
         year=1,
         month=1,
@@ -22,12 +61,12 @@ def long_time_range(
         minute=0,
         second=0,
     )
-    return begin, end
+    return DateTimeRange(begin, end)
 
 
 def millenium_range(
     dt: datetime.datetime,
-) -> Tuple[datetime.datetime, datetime.datetime]:
+) -> DateTimeRange:
     begin_of_millenium = datetime.datetime.min.replace(
         year=(dt.year - 1) // 1000 * 1000 + 1,
         month=1,
@@ -44,12 +83,12 @@ def millenium_range(
         minute=0,
         second=0,
     )
-    return begin_of_millenium, end_of_millenium
+    return DateTimeRange(begin_of_millenium, end_of_millenium)
 
 
 def century_range(
     dt: datetime.datetime,
-) -> Tuple[datetime.datetime, datetime.datetime]:
+) -> DateTimeRange:
     begin_of_century = datetime.datetime.min.replace(
         year=(dt.year - 1) // 100 * 100 + 1,
         month=1,
@@ -66,12 +105,12 @@ def century_range(
         minute=0,
         second=0,
     )
-    return begin_of_century, end_of_century
+    return DateTimeRange(begin_of_century, end_of_century)
 
 
 def year_range(
     dt: datetime.datetime,
-) -> Tuple[datetime.datetime, datetime.datetime]:
+) -> DateTimeRange:
     begin_of_year = datetime.datetime.min.replace(
         year=dt.year,
         month=1,
@@ -88,12 +127,12 @@ def year_range(
         minute=0,
         second=0,
     )
-    return begin_of_year, end_of_year
+    return DateTimeRange(begin_of_year, end_of_year)
 
 
 def month_range(
     dt: datetime.datetime,
-) -> Tuple[datetime.datetime, datetime.datetime]:
+) -> DateTimeRange:
     begin_of_month = datetime.datetime.min.replace(
         year=dt.year,
         month=dt.month,
@@ -111,12 +150,12 @@ def month_range(
         minute=0,
         second=0,
     ) + datetime.timedelta(days=1)
-    return begin_of_month, end_of_month
+    return DateTimeRange(begin_of_month, end_of_month)
 
 
 def week_range(
     dt: datetime.datetime,
-) -> Tuple[datetime.datetime, datetime.datetime]:
+) -> DateTimeRange:
     begin_of_week = datetime.datetime.min.replace(
         year=dt.year,
         month=dt.month,
@@ -133,12 +172,12 @@ def week_range(
         minute=0,
         second=0,
     ) + datetime.timedelta(days=7 - dt.weekday())
-    return begin_of_week, end_of_week
+    return DateTimeRange(begin_of_week, end_of_week)
 
 
 def day_range(
     dt: datetime.datetime,
-) -> Tuple[datetime.datetime, datetime.datetime]:
+) -> DateTimeRange:
     begin_of_day = datetime.datetime.min.replace(
         year=dt.year,
         month=dt.month,
@@ -155,15 +194,4 @@ def day_range(
         minute=0,
         second=0,
     ) + datetime.timedelta(days=1)
-    return begin_of_day, end_of_day
-
-
-def time_elapsed_ratio(
-    *,
-    begin: datetime.datetime,
-    end: datetime.datetime,
-    current: datetime.datetime,
-) -> float:
-    total_seconds = (end - begin).total_seconds()
-    elapsed_time = (current - begin).total_seconds()
-    return elapsed_time / total_seconds
+    return DateTimeRange(begin_of_day, end_of_day)


### PR DESCRIPTION
datetime_to_vecs, datetime_from_vecs were completely rewritten.
There are various vectors that represent time, but by applying them in order of magnitude, the error becomes small.
This makes it possible to handle both cases where only a few types of vectors are sufficient and cases where many types of vectors are used.
