### PR TITLE
WIP: support-python-314

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           actual_version=$(uv run python --version)
           expected_version="Python ${{ matrix.python }}"
-          if [ "$actual_version" == *"$expected_version"* ]; then
+          if [ "$actual_version" != *"$expected_version"* ]; then
             echo "Expected $expected_version, but got $actual_version"
             exit 1
           fi
@@ -50,4 +50,3 @@ jobs:
 
       - name: Coverage
         run: uv run poe coverage-xml
-

--- a/timevec/numpy_datetime64.py
+++ b/timevec/numpy_datetime64.py
@@ -84,7 +84,7 @@ def datetime64_to_datetime(dt: np.datetime64) -> datetime.datetime:
     ts = float(
         (dt64 - np.datetime64("1970-01-01T00:00:00")) / np.timedelta64(1, "s")
     )
-    return datetime.datetime.utcfromtimestamp(ts)
+    return datetime.datetime.fromtimestamp(ts, datetime.UTC).replace(tzinfo=None)
 
 
 def datetime_to_datetime64(dt: datetime.datetime) -> np.datetime64:

--- a/timevec/numpy_datetime64.py
+++ b/timevec/numpy_datetime64.py
@@ -84,7 +84,9 @@ def datetime64_to_datetime(dt: np.datetime64) -> datetime.datetime:
     ts = float(
         (dt64 - np.datetime64("1970-01-01T00:00:00")) / np.timedelta64(1, "s")
     )
-    return datetime.datetime.fromtimestamp(ts, datetime.UTC).replace(tzinfo=None)
+    return datetime.datetime.fromtimestamp(
+        ts, datetime.timezone.utc
+    ).replace(tzinfo=None)
 
 
 def datetime_to_datetime64(dt: datetime.datetime) -> np.datetime64:


### PR DESCRIPTION
## Summary
- Fix CI Python version validation logic so matrix jobs fail only on version mismatch.
- Replace deprecated UTC conversion API usage with a Python 3.10+ compatible implementation.
- refs: https://github.com/kitsuyui/python-timevec/pull/344

## Validation
- `uv run poe check`
- `uv run poe test`

## CI Fix Note
- Previous Test workflow failure was caused by `datetime.UTC` not being available under Python 3.10 type checking.
- Updated implementation now uses `datetime.timezone.utc`.
