### PR TITLE
Tighten Ruff lint rules

### DIFF
--- a/examples/plot.py
+++ b/examples/plot.py
@@ -1,15 +1,17 @@
 # ja: 実際に year_vec がどのような値を返すかのグラフを描き、わかりやすくします。
 
 import datetime
-import numpy as np
-from typing import Callable, List
+from collections.abc import Callable
+
 import matplotlib.pyplot as plt
+import numpy as np
+
 import timevec.numpy as tv
 
 
-def plot_func_vec(func: Callable[[datetime.datetime], np.ndarray], dates: List[datetime.datetime]) -> None:
+def plot_func_vec(func: Callable[[datetime.datetime], np.ndarray], dates: list[datetime.datetime]) -> None:
     vecs = np.array([func(dt) for dt in dates])
-    fig, ax = plt.subplots()
+    _fig, _ax = plt.subplots()
     plt.plot(vecs)
     plt.savefig(f"examples/{func.__name__}.svg")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,48 @@ check = [
 [tool.ruff]
 line-length = 79
 
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "COM",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+ignore = [
+    "A001",
+    "A002",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"examples/**/*.py" = [
+    "ANN",
+    "D",
+    "E501",
+]
+"tests/**/*.py" = [
+    "ANN",
+    "D",
+    "E501",
+    "S101",
+    "S311",
+]
+
 [tool.mypy]
 strict = true
 ignore_missing_imports = false

--- a/tests/test_builtin_math.py
+++ b/tests/test_builtin_math.py
@@ -1,7 +1,7 @@
 import datetime
+from collections.abc import Callable
 
 import pytest
-from typing import Tuple, Callable
 
 import timevec.builtin_math as tv
 import timevec.util as util
@@ -13,7 +13,7 @@ def assert_vector_in_circle(x: float, y: float, *, abs: float = 1e-6) -> None:
 
 def assert_vector_continuity(
     dt: datetime.datetime,
-    fn: Callable[[datetime.datetime], Tuple[float, float]],
+    fn: Callable[[datetime.datetime], tuple[float, float]],
     eps_timedelta: datetime.timedelta = datetime.timedelta(seconds=0.01),
 ) -> None:
     """Test that the vector is continuous and in the same basis"""
@@ -42,7 +42,7 @@ def assert_vector_continuity(
 
 def assert_range_vector_value(
     range: util.DateTimeRange,
-    fn: Callable[[datetime.datetime], Tuple[float, float]],
+    fn: Callable[[datetime.datetime], tuple[float, float]],
     *,
     abs: float = 1e-6,
 ) -> None:

--- a/tests/test_many_dates.py
+++ b/tests/test_many_dates.py
@@ -1,10 +1,12 @@
-from typing import Iterable, Literal
+import datetime
+from collections.abc import Iterable
+from typing import Literal
 
+import numpy as np
+
+import timevec.builtin_math as tv
 import timevec.numpy as tvn
 import timevec.numpy_datetime64 as tv64
-import timevec.builtin_math as tv
-import numpy as np
-import datetime
 
 
 def test_many_dates() -> None:
@@ -30,7 +32,7 @@ def test_many_dates() -> None:
     ]
 
     # try all the functions does not raise an exception
-    for i in range(50000):
+    for _i in range(50000):
         dt += datetime.timedelta(days=17, hours=13, minutes=11, seconds=7)
 
         vecs2 = tv.datetime_to_vecs(dt, full)

--- a/tests/test_numpy_datetime64.py
+++ b/tests/test_numpy_datetime64.py
@@ -2,8 +2,8 @@ import datetime
 
 import numpy as np
 
-import timevec.numpy_datetime64 as tv64
 import timevec.numpy as tv
+import timevec.numpy_datetime64 as tv64
 
 
 def test_long_time_vec() -> None:

--- a/tests/test_same_result.py
+++ b/tests/test_same_result.py
@@ -2,19 +2,20 @@
 from __future__ import annotations
 
 import datetime
-
-from typing import Callable, Tuple, List
 import random
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
 import timevec.builtin_math as tv
 import timevec.numpy as tvn
 import timevec.numpy_datetime64 as tv64
-import numpy as np
-import pytest
 
 
 def assert_same(
     dt: datetime.datetime,
-    func1: Callable[[datetime.datetime], Tuple[float, float]],
+    func1: Callable[[datetime.datetime], tuple[float, float]],
     func2: Callable[[datetime.datetime], np.ndarray],
     func3: Callable[[np.datetime64], np.ndarray],
     *,
@@ -41,12 +42,9 @@ def random_date() -> datetime.datetime:
     return datetime.datetime(year, month, day, hour, minute, second)
 
 
-def random_dates(size: int = 2000) -> List[datetime.datetime]:
+def random_dates(size: int = 2000) -> list[datetime.datetime]:
     """Return a list of random datetimes."""
-    dates = []
-    for _ in range(size):
-        dates.append(random_date())
-    return dates
+    return [random_date() for _ in range(size)]
 
 
 def test_long_time_vec() -> None:
@@ -78,7 +76,7 @@ def test_month_vec() -> None:
     for dt in test_dates:
         assert_same(dt, tv.month_vec, tvn.month_vec, tv64.month_vec)
 
-    
+
 def test_week_vec() -> None:
     test_dates = random_dates()
     for dt in test_dates:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,14 +1,14 @@
 import datetime
 
 from timevec.util import (
+    DateTimeRange,
+    century_range,
     day_range,
+    long_time_range,
+    millennium_range,
     month_range,
     week_range,
-    century_range,
-    millennium_range,
-    long_time_range,
     year_range,
-    DateTimeRange,
 )
 
 
@@ -28,7 +28,7 @@ def assert_date_time_range(range: DateTimeRange) -> None:
 def test_date_time_range() -> None:
     """Test DateTimeRange"""
     range = DateTimeRange(
-        datetime.datetime(2000, 1, 1), datetime.datetime(2000, 1, 2)
+        datetime.datetime(2000, 1, 1), datetime.datetime(2000, 1, 2),
     )
     assert_date_time_range(range)
     assert range.begin == datetime.datetime(2000, 1, 1)
@@ -43,7 +43,7 @@ def test_long_time_range() -> None:
     assert range.begin == datetime.datetime(1, 1, 1)
     assert range.end == datetime.datetime(5001, 1, 1)
     assert range.total_time == datetime.timedelta(
-        days=1826212
+        days=1826212,
     )  # 5000 years contains 1212 leap years
 
 

--- a/timevec/__init__.py
+++ b/timevec/__init__.py
@@ -1,33 +1,32 @@
 """Time vector representation
 
-Time has a periodic nature due to the rotation of the earth and the position of the sun.
+Time has a periodic nature due to the rotation of the earth
+and the position of the sun.
 This affects human behavior in various ways.
 
 Seasonality ... periodicity in a year (seasonal distinction)
 Daily periodicity ... periodicity in a day (distinction between day and night)
-Day of the week ... periodicity in a week (distinction between weekdays and holidays)
+Day of the week ... periodicity in a week
+(distinction between weekdays and holidays)
 
 When dealing with these, it is desirable to vectorize with periodicity in mind.
-That is, at 23:59 on a given day, it is desirable that the value is close to 00:00 on the next day.
+That is, at 23:59 on a given day,
+it is desirable that the value is close to 00:00 on the next day.
 To achieve this, the time is represented as a combination of cos and sin."""
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
+import contextlib
+
 from ._version import __version__
 
-try:
+with contextlib.suppress(ImportError):
     from . import builtin_math
-except ImportError:
-    pass
 
-try:
+with contextlib.suppress(ImportError):
     from . import numpy_datetime64
-except ImportError:
-    pass
 
-try:
+with contextlib.suppress(ImportError):
     from . import numpy
-except ImportError:
-    pass
 
 
-__all__ = ["builtin_math", "numpy_datetime64", "numpy", "__version__"]
+__all__ = ["__version__", "builtin_math", "numpy", "numpy_datetime64"]

--- a/timevec/builtin_math.py
+++ b/timevec/builtin_math.py
@@ -1,53 +1,53 @@
 import datetime
 import math
-from typing import Dict, Iterable, Tuple
+from collections.abc import Iterable
 
 import timevec.util as util
 
 
-def long_time_vec(dt: datetime.datetime) -> Tuple[float, float]:
+def long_time_vec(dt: datetime.datetime) -> tuple[float, float]:
     """Represent the elapsed time in the long time as a vector"""
     range = util.long_time_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
-def millennium_vec(dt: datetime.datetime) -> Tuple[float, float]:
+def millennium_vec(dt: datetime.datetime) -> tuple[float, float]:
     """Represent the elapsed time in the millennium as a vector"""
     range = util.millennium_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
-def century_vec(dt: datetime.datetime) -> Tuple[float, float]:
+def century_vec(dt: datetime.datetime) -> tuple[float, float]:
     """Represent the elapsed time in the century as a vector"""
     range = util.century_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
-def decade_vec(dt: datetime.datetime) -> Tuple[float, float]:
+def decade_vec(dt: datetime.datetime) -> tuple[float, float]:
     """Represent the elapsed time in the decade as a vector"""
     range = util.decade_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
-def year_vec(dt: datetime.datetime) -> Tuple[float, float]:
+def year_vec(dt: datetime.datetime) -> tuple[float, float]:
     """Represent the elapsed time in the year as a vector"""
     range = util.year_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
-def month_vec(dt: datetime.datetime) -> Tuple[float, float]:
+def month_vec(dt: datetime.datetime) -> tuple[float, float]:
     """Represent the elapsed time in the month as a vector"""
     range = util.month_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
-def week_vec(dt: datetime.datetime) -> Tuple[float, float]:
+def week_vec(dt: datetime.datetime) -> tuple[float, float]:
     """Represent the elapsed time in the week as a vector"""
     # weekday is 0 for Monday and 6 for Sunday
     range = util.week_range(dt)
@@ -55,14 +55,14 @@ def week_vec(dt: datetime.datetime) -> Tuple[float, float]:
     return ratio_to_vec(rate)
 
 
-def day_vec(dt: datetime.datetime) -> Tuple[float, float]:
+def day_vec(dt: datetime.datetime) -> tuple[float, float]:
     """Represent the elapsed time in the day as a vector"""
     range = util.day_range(dt)
     rate = range.time_elapsed_ratio(dt)
     return ratio_to_vec(rate)
 
 
-def ratio_to_vec(rate: float) -> Tuple[float, float]:
+def ratio_to_vec(rate: float) -> tuple[float, float]:
     """Convert a rate to a vector"""
     s = 2 * math.pi * rate
     x = math.cos(s)
@@ -81,9 +81,9 @@ def vec_to_ratio(x: float, y: float) -> float:
 def datetime_to_vecs(
     dt: datetime.datetime,
     targets: Iterable[util.TARGET],
-) -> Dict[util.TARGET, Tuple[float, float]]:
+) -> dict[util.TARGET, tuple[float, float]]:
     """Convert a datetime to a vector"""
-    d: Dict[util.TARGET, Tuple[float, float]] = {}
+    d: dict[util.TARGET, tuple[float, float]] = {}
     if "long_time" in targets:
         d["long_time"] = long_time_vec(dt)
     if "millennium" in targets:
@@ -104,7 +104,7 @@ def datetime_to_vecs(
 
 
 def datetime_from_vecs(
-    items: Dict[util.TARGET, Tuple[float, float]],
+    items: dict[util.TARGET, tuple[float, float]],
 ) -> datetime.datetime:
     """Convert a vector to a datetime"""
     # long time → millennium → century → decade → year → month → week → day
@@ -146,14 +146,14 @@ def datetime_from_vecs(
 
 
 __all__ = [
+    "century_vec",
+    "datetime_from_vecs",
+    "datetime_to_vecs",
+    "day_vec",
+    "decade_vec",
     "long_time_vec",
     "millennium_vec",
-    "century_vec",
-    "decade_vec",
-    "year_vec",
     "month_vec",
     "week_vec",
-    "day_vec",
-    "datetime_to_vecs",
-    "datetime_from_vecs",
+    "year_vec",
 ]

--- a/timevec/numpy.py
+++ b/timevec/numpy.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import numpy.typing as npt
@@ -8,7 +8,7 @@ import timevec.util as util
 
 
 def long_time_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
+    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the long time as a vector"""
     range = util.long_time_range(dt)
@@ -17,7 +17,7 @@ def long_time_vec(
 
 
 def millennium_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
+    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the millennium as a vector"""
     range = util.millennium_range(dt)
@@ -26,7 +26,7 @@ def millennium_vec(
 
 
 def century_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
+    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the century as a vector"""
     range = util.century_range(dt)
@@ -35,7 +35,7 @@ def century_vec(
 
 
 def decade_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
+    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the decade as a vector"""
     range = util.decade_range(dt)
@@ -44,7 +44,7 @@ def decade_vec(
 
 
 def year_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
+    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the year as a vector"""
     range = util.year_range(dt)
@@ -53,7 +53,7 @@ def year_vec(
 
 
 def month_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
+    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the month as a vector"""
     range = util.month_range(dt)
@@ -62,7 +62,7 @@ def month_vec(
 
 
 def week_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
+    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the week as a vector"""
     range = util.week_range(dt)
@@ -71,7 +71,7 @@ def week_vec(
 
 
 def day_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64
+    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the day as a vector"""
     range = util.day_range(dt)
@@ -80,7 +80,7 @@ def day_vec(
 
 
 def ratio_to_vec(
-    ratio: float, *, dtype: npt.DTypeLike = np.float64
+    ratio: float, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the ratio as a vector"""
     vec = np.zeros(2, dtype=dtype)
@@ -102,9 +102,9 @@ def datetime_to_vecs(
     targets: Iterable[util.TARGET],
     *,
     dtype: npt.DTypeLike = np.float64,
-) -> Dict[util.TARGET, npt.NDArray]:
+) -> dict[util.TARGET, npt.NDArray]:
     """Convert a datetime to a vector"""
-    d: Dict[util.TARGET, npt.NDArray] = {}
+    d: dict[util.TARGET, npt.NDArray] = {}
     if "long_time" in targets:
         d["long_time"] = long_time_vec(dt, dtype=dtype)
     if "millennium" in targets:
@@ -125,7 +125,7 @@ def datetime_to_vecs(
 
 
 def datetime_from_vecs(
-    items: Dict[util.TARGET, npt.NDArray],
+    items: dict[util.TARGET, npt.NDArray],
 ) -> datetime.datetime:
     """Convert a vector to a datetime"""
     # long time → millennium → century → decade → year → month → week → day
@@ -168,12 +168,12 @@ def datetime_from_vecs(
 
 __all__ = [
     "century_vec",
+    "datetime_from_vecs",
+    "datetime_to_vecs",
     "day_vec",
     "long_time_vec",
     "millennium_vec",
     "month_vec",
     "week_vec",
     "year_vec",
-    "datetime_from_vecs",
-    "datetime_to_vecs",
 ]

--- a/timevec/numpy_datetime64.py
+++ b/timevec/numpy_datetime64.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import numpy.typing as npt
@@ -9,7 +9,7 @@ import timevec.util as util
 
 
 def long_time_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64
+    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the long time as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -19,7 +19,7 @@ def long_time_vec(
 
 
 def millennium_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64
+    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the millennium as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -29,7 +29,7 @@ def millennium_vec(
 
 
 def century_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64
+    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the century as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -39,7 +39,7 @@ def century_vec(
 
 
 def year_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64
+    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the year as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -49,7 +49,7 @@ def year_vec(
 
 
 def month_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64
+    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the month as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -59,7 +59,7 @@ def month_vec(
 
 
 def week_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64
+    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the week as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -69,7 +69,7 @@ def week_vec(
 
 
 def day_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64
+    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the day as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -82,7 +82,7 @@ def datetime64_to_datetime(dt: np.datetime64) -> datetime.datetime:
     """Convert a numpy.datetime64 to a datetime.datetime"""
     dt64 = np.datetime64(dt)
     ts = float(
-        (dt64 - np.datetime64("1970-01-01T00:00:00")) / np.timedelta64(1, "s")
+        (dt64 - np.datetime64("1970-01-01T00:00:00")) / np.timedelta64(1, "s"),
     )
     return datetime.datetime.utcfromtimestamp(ts)
 
@@ -90,8 +90,7 @@ def datetime64_to_datetime(dt: np.datetime64) -> datetime.datetime:
 def datetime_to_datetime64(dt: datetime.datetime) -> np.datetime64:
     """Convert a datetime.datetime to a numpy.datetime64"""
     ts = dt.timestamp()
-    dt64 = np.datetime64("1970-01-01T00:00:00") + np.timedelta64(int(ts), "s")
-    return dt64
+    return np.datetime64("1970-01-01T00:00:00") + np.timedelta64(int(ts), "s")
 
 
 def datetime64_to_vecs(
@@ -99,14 +98,14 @@ def datetime64_to_vecs(
     targets: Iterable[util.TARGET],
     *,
     dtype: npt.DTypeLike = np.float64,
-) -> Dict[util.TARGET, npt.NDArray]:
+) -> dict[util.TARGET, npt.NDArray]:
     """Convert a numpy.datetime64 to a vector"""
     dt2 = datetime64_to_datetime(dt)
     return tvn.datetime_to_vecs(dt2, targets, dtype=dtype)
 
 
 def datetime64_from_vecs(
-    items: Dict[util.TARGET, npt.NDArray],
+    items: dict[util.TARGET, npt.NDArray],
 ) -> np.datetime64:
     """Convert a vector to a numpy.datetime64"""
     dt = tvn.datetime_from_vecs(items)
@@ -115,12 +114,12 @@ def datetime64_from_vecs(
 
 __all__ = [
     "century_vec",
+    "datetime64_from_vecs",
+    "datetime64_to_vecs",
     "day_vec",
     "long_time_vec",
     "millennium_vec",
     "month_vec",
     "week_vec",
     "year_vec",
-    "datetime64_from_vecs",
-    "datetime64_to_vecs",
 ]

--- a/timevec/util.py
+++ b/timevec/util.py
@@ -71,7 +71,7 @@ END_OF_DATETIME = datetime.datetime(5001, 1, 1, 0, 0, 0)
 
 
 def long_time_range(
-    dt: datetime.datetime,
+    _dt: datetime.datetime,
 ) -> DateTimeRange:
     """Return a DateTimeRange that covers a long time period"""
     return DateTimeRange(
@@ -244,12 +244,12 @@ def day_range(
 
 __all__ = [
     "DateTimeRange",
+    "century_range",
+    "day_range",
+    "decade_range",
     "long_time_range",
     "millennium_range",
-    "century_range",
-    "decade_range",
-    "year_range",
     "month_range",
     "week_range",
-    "day_range",
+    "year_range",
 ]


### PR DESCRIPTION
## Summary

Tighten the Ruff lint configuration with a stricter, low-friction rule set.

## Changes

- enable a broader set of non-framework-specific Ruff rules
- keep test files practical with targeted per-file ignores where needed
- update code that was auto-fixable or low-cost to adjust manually

## Verification

- `uv run poe check`
- `uv run poe test`
