### PR TITLE
Fix decade range near datetime minimum

### DIFF
--- a/tests/test_same_result.py
+++ b/tests/test_same_result.py
@@ -23,7 +23,6 @@ def assert_same(
     abs_tol: float = 0.0,
 ) -> None:
     """Assert that the functions return the same result."""
-    dt = datetime.datetime(2020, 1, 1, 0, 0, 0)
     result1 = func1(dt)
     result2 = func2(dt)
     result3 = func3(np.datetime64(dt))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,7 @@ from timevec.util import (
     DateTimeRange,
     century_range,
     day_range,
+    decade_range,
     long_time_range,
     millennium_range,
     month_range,
@@ -63,6 +64,14 @@ def test_century_range() -> None:
     assert range.begin == datetime.datetime(1901, 1, 1)
     assert range.end == datetime.datetime(2001, 1, 1)
     assert range.total_time == datetime.timedelta(days=36525)
+
+
+def test_decade_range_near_datetime_min() -> None:
+    """Test decade_range() for years where 0-based decade math underflows."""
+    range = decade_range(datetime.datetime(1, 1, 1))
+    assert_date_time_range(range)
+    assert range.begin == datetime.datetime(1, 1, 1)
+    assert range.end == datetime.datetime(11, 1, 1)
 
 
 def test_year_range() -> None:

--- a/timevec/util.py
+++ b/timevec/util.py
@@ -130,8 +130,9 @@ def decade_range(
     dt: datetime.datetime,
 ) -> DateTimeRange:
     """Return a DateTimeRange that covers a decade"""
+    decade_start_year = (dt.year - 1) // 10 * 10 + 1
     begin_of_decade = datetime.datetime.min.replace(
-        year=dt.year // 10 * 10,
+        year=decade_start_year,
         month=1,
         day=1,
         hour=0,
@@ -139,7 +140,7 @@ def decade_range(
         second=0,
     )
     end_of_decade = datetime.datetime.min.replace(
-        year=dt.year // 10 * 10 + 10,
+        year=decade_start_year + 10,
         month=1,
         day=1,
         hour=0,


### PR DESCRIPTION
## Summary
- use 1-based decade math so years 1 through 9 do not underflow to year 0
- keep randomized datetime inputs in assert_same instead of replacing them with a fixed date
- add a regression test for decade_range near datetime.min

## Verification
- uv run poe check
- uv run poe test
- git diff --check