### PR TITLE
Add actionlint workflow check

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,6 +9,20 @@ on:
       - main
 
 jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Run actionlint
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -40,7 +54,7 @@ jobs:
         run: |
           actual_version=$(uv run python --version)
           expected_version="Python ${{ matrix.python }}"
-          if [ "$actual_version" == *"$expected_version"* ]; then
+          if [[ "$actual_version" != *"$expected_version"* ]]; then
             echo "Expected $expected_version, but got $actual_version"
             exit 1
           fi
@@ -50,4 +64,3 @@ jobs:
 
       - name: Coverage
         run: uv run poe coverage-xml
-


### PR DESCRIPTION
## Summary
- Add an actionlint job to the test workflow so GitHub Actions syntax and inline shell fragments are checked in CI.
- Fix the Python version check to use bash glob matching and fail only when the actual version does not match the matrix entry.

## Verification
- actionlint .github/workflows/*.yml
- git diff --check
- uv run poe check
- uv run poe test
- uv run poe coverage-xml

## Notes
- The local test and coverage commands pass with existing deprecation warnings from datetime.utcfromtimestamp usage.
