### PR TITLE
docs: document NumPy extra installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,39 @@ This is called a time vector.
 
 # Installation
 
+The base package has no NumPy dependency and supports
+`timevec.builtin_math`:
+
 ```sh
 pip install timevec
 ```
 
+Install the `numpy` extra when you use `timevec.numpy` or
+`timevec.numpy_datetime64`:
+
+```sh
+pip install "timevec[numpy]"
+```
+
 # Usage
 
+With the base install:
+
 ```python
-import timevec.numpy as tv
 import datetime
+import timevec.builtin_math as tv
+
+dt = datetime.datetime(2020, 1, 1, 0, 0, 0)
+vec = tv.year_vec(dt)
+# (1.0, 0.0)
+```
+
+With the `numpy` extra:
+
+```python
+import datetime
+import timevec.numpy as tv
+
 dt = datetime.datetime(2020, 1, 1, 0, 0, 0)
 vec = tv.year_vec(dt)
 # array([1., 0.])


### PR DESCRIPTION
## Summary

- Clarify that the base installation has no NumPy dependency and supports `timevec.builtin_math`.
- Document `pip install "timevec[numpy]"` for `timevec.numpy` and `timevec.numpy_datetime64`.
- Split the README usage examples into base and NumPy-extra paths.

## Why

The README installed the base package but immediately showed a `timevec.numpy` example. Since NumPy is provided through the optional `numpy` extra, users following the README could hit an import error after installing only `timevec`.

## Validation

- `git diff --check`
- `uv run poe check`
- `uv run poe test`
- `uv run python -m pytest tests/test_builtin_math.py tests/test_numpy.py tests/test_numpy_datetime64.py`
- `uv run --with build python -m build --outdir .tmp/build`
- `uv run --with twine twine check .tmp/build/*`
- `uv run --isolated --no-project --with . python -c 'import importlib.util; assert importlib.util.find_spec("numpy") is None; import datetime; import timevec.builtin_math as tv; assert tv.year_vec(datetime.datetime(2020, 1, 1)) == (1.0, 0.0)'`
- `uv run --isolated --no-project --with '.[numpy]' python -c 'import datetime; import timevec.numpy as tv; vec = tv.year_vec(datetime.datetime(2020, 1, 1)); assert vec.tolist() == [1.0, 0.0]'`
