### PR TITLE
Pin Octocov workflow action refs

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -20,16 +20,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: |
@@ -44,7 +44,7 @@ jobs:
 
       # See also: https://github.com/k1LoW/octocov-action
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml


### PR DESCRIPTION
## Summary
- Pin the Octocov workflow action refs to full commit SHAs.
- Keep the previous release tags as inline comments for update context.

## Verification
- `actionlint .github/workflows/octocov.yml`
- `git diff --check`
- Verified each pinned SHA through the GitHub API.