### PR TITLE
Pin test workflow actions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,16 +22,16 @@ jobs:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Pin the external actions used by the Python test workflow to immutable commit SHAs.
- Keep the existing workflow behavior unchanged while avoiding moving tag references.

## Verification
- `actionlint .github/workflows/*.yml`
- `git diff --check origin/main...HEAD`
- Confirmed each pinned action commit resolves through the GitHub API.
