### PR TITLE
Enable uv dependency caching in workflows

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Enable setup-uv caching in the test, coverage, and packaging workflows.
- Key the cache from `uv.lock` so dependency installs can reuse the uv cache until the lockfile changes.

## Checks
- `actionlint .github/workflows/*.yml`
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
