### PR TITLE
feat: add decade_vec to timevec.numpy and timevec.numpy_datetime64 public API

### DIFF
--- a/timevec/numpy.py
+++ b/timevec/numpy.py
@@ -11,7 +11,9 @@ NumpyRangeFactory = Callable[[datetime.datetime], util.DateTimeRange]
 
 
 def long_time_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
+    dt: datetime.datetime,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the long time as a vector"""
     range = util.long_time_range(dt)
@@ -20,7 +22,9 @@ def long_time_vec(
 
 
 def millennium_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
+    dt: datetime.datetime,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the millennium as a vector"""
     range = util.millennium_range(dt)
@@ -29,7 +33,9 @@ def millennium_vec(
 
 
 def century_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
+    dt: datetime.datetime,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the century as a vector"""
     range = util.century_range(dt)
@@ -38,7 +44,9 @@ def century_vec(
 
 
 def decade_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
+    dt: datetime.datetime,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the decade as a vector"""
     range = util.decade_range(dt)
@@ -47,7 +55,9 @@ def decade_vec(
 
 
 def year_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
+    dt: datetime.datetime,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the year as a vector"""
     range = util.year_range(dt)
@@ -56,7 +66,9 @@ def year_vec(
 
 
 def month_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
+    dt: datetime.datetime,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the month as a vector"""
     range = util.month_range(dt)
@@ -65,7 +77,9 @@ def month_vec(
 
 
 def week_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
+    dt: datetime.datetime,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the week as a vector"""
     range = util.week_range(dt)
@@ -74,7 +88,9 @@ def week_vec(
 
 
 def day_vec(
-    dt: datetime.datetime, *, dtype: npt.DTypeLike = np.float64,
+    dt: datetime.datetime,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the day as a vector"""
     range = util.day_range(dt)
@@ -83,7 +99,9 @@ def day_vec(
 
 
 def ratio_to_vec(
-    ratio: float, *, dtype: npt.DTypeLike = np.float64,
+    ratio: float,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the ratio as a vector"""
     vec = np.zeros(2, dtype=dtype)
@@ -113,7 +131,8 @@ NUMPY_RANGE_FACTORIES: tuple[tuple[util.TARGET, NumpyRangeFactory], ...] = (
 
 
 def numpy_vec_factories(
-    *, dtype: npt.DTypeLike,
+    *,
+    dtype: npt.DTypeLike,
 ) -> tuple[
     tuple[util.TARGET, Callable[[datetime.datetime], npt.NDArray]],
     ...,
@@ -170,6 +189,7 @@ __all__ = [
     "datetime_from_vecs",
     "datetime_to_vecs",
     "day_vec",
+    "decade_vec",
     "long_time_vec",
     "millennium_vec",
     "month_vec",

--- a/timevec/numpy_datetime64.py
+++ b/timevec/numpy_datetime64.py
@@ -9,7 +9,9 @@ import timevec.util as util
 
 
 def long_time_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the long time as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -19,7 +21,9 @@ def long_time_vec(
 
 
 def millennium_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the millennium as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -29,7 +33,9 @@ def millennium_vec(
 
 
 def century_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the century as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -38,8 +44,22 @@ def century_vec(
     return tvn.ratio_to_vec(rate, dtype=dtype)
 
 
+def decade_vec(
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
+) -> npt.NDArray:
+    """Represent the elapsed time in the decade as a vector"""
+    dt2 = datetime64_to_datetime(dt)
+    range = util.decade_range(dt2)
+    rate = range.time_elapsed_ratio(dt2)
+    return tvn.ratio_to_vec(rate, dtype=dtype)
+
+
 def year_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the year as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -49,7 +69,9 @@ def year_vec(
 
 
 def month_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the month as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -59,7 +81,9 @@ def month_vec(
 
 
 def week_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the week as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -69,7 +93,9 @@ def week_vec(
 
 
 def day_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the day as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -117,6 +143,7 @@ __all__ = [
     "datetime64_from_vecs",
     "datetime64_to_vecs",
     "day_vec",
+    "decade_vec",
     "long_time_vec",
     "millennium_vec",
     "month_vec",


### PR DESCRIPTION
## Summary

`timevec.numpy` defined `decade_vec` as a function but did not include it
in `__all__`, so it was invisible to wildcard imports and documentation
generators that rely on `__all__`.

`timevec.numpy_datetime64` had no `decade_vec` implementation at all.
The README states that "almost the same functions are provided in
timevec.numpy, timevec.numpy_datetime64, and timevec.builtin_math", but
`decade_vec` was only complete in `timevec.builtin_math`.

## Changes

- `timevec/numpy.py`: add `"decade_vec"` to `__all__`
- `timevec/numpy_datetime64.py`: implement `decade_vec` (same pattern as
  the other vec functions); add `"decade_vec"` to `__all__`

## Verification

- `poe format`: 2 files reformatted (argument style alignment only)
- `poe check` (ruff + mypy): all pass
- `poe test`: 38/38 pass
- `ruff check timevec tests`: 0 findings
