### PR TITLE
fix: raise ValueError for zero vector input in vec_to_ratio

### DIFF
--- a/tests/test_builtin_math.py
+++ b/tests/test_builtin_math.py
@@ -178,3 +178,8 @@ def test_edge_cases() -> None:
     dt = datetime.datetime(2023, 12, 31, 23, 59, 59, 999999)
     x, y = tv.year_vec(dt)
     assert (x, y) == pytest.approx((1.0, 0.0), abs=1e-6)
+
+
+def test_vec_to_ratio_zero_vector_raises() -> None:
+    with pytest.raises(ValueError):
+        tv.vec_to_ratio(0.0, 0.0)

--- a/timevec/builtin_math.py
+++ b/timevec/builtin_math.py
@@ -75,6 +75,11 @@ def ratio_to_vec(rate: float) -> tuple[float, float]:
 
 def vec_to_ratio(x: float, y: float) -> float:
     """Convert a vector to a rate"""
+    if x == 0.0 and y == 0.0:
+        raise ValueError(
+            "vec_to_ratio received a zero vector (0, 0);"
+            " input must be a unit vector",
+        )
     # atan2 returns a value in the range [-pi, pi]
     # so we need to convert it to the range [0, 2*pi]
     angle = math.atan2(y, x) / (2.0 * math.pi)


### PR DESCRIPTION
## Summary

`vec_to_ratio(0.0, 0.0)` silently returned `0.0` (the start of the period) for zero-vector input because `math.atan2(0, 0) == 0.0` under IEEE 754. A zero vector is outside the valid domain of `vec_to_ratio` — it expects a unit vector produced by `ratio_to_vec`.

This change adds an explicit guard that raises `ValueError` when both `x` and `y` are `0.0`, surfacing corrupted or out-of-domain input instead of silently mapping it to the start of the period.

## Changes

- `timevec/builtin_math.py`: raise `ValueError` at the top of `vec_to_ratio` when `x == 0.0 and y == 0.0`
- `tests/test_builtin_math.py`: add `test_vec_to_ratio_zero_vector_raises` to verify the guard

## Verification

- All 39 tests pass (`uv run pytest`)
- `ruff check` and `mypy` clean