### PR TITLE
fix: raise ValueError for zero-duration elapsed ratios

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from timevec.util import (
     DateTimeRange,
     century_range,
@@ -35,6 +37,15 @@ def test_date_time_range() -> None:
     assert range.begin == datetime.datetime(2000, 1, 1)
     assert range.end == datetime.datetime(2000, 1, 2)
     assert range.total_time == datetime.timedelta(days=1)
+
+
+def test_time_elapsed_ratio_rejects_zero_duration_range() -> None:
+    """Test zero-duration DateTimeRange elapsed ratio contract."""
+    instant = datetime.datetime(2000, 1, 1)
+    range = DateTimeRange(instant, instant)
+
+    with pytest.raises(ValueError, match="non-zero duration"):
+        range.time_elapsed_ratio(instant)
 
 
 def test_long_time_range() -> None:

--- a/timevec/util.py
+++ b/timevec/util.py
@@ -48,10 +48,14 @@ class DateTimeRange:
         return self.begin + self.elapsed_time_by_ratio(ratio)
 
     def time_elapsed_ratio(self, current: datetime.datetime) -> float:
-        return (
-            self.elapsed_time(current).total_seconds()
-            / self.total_time.total_seconds()
-        )
+        total_seconds = self.total_time.total_seconds()
+        if total_seconds == 0.0:
+            msg = (
+                "DateTimeRange.time_elapsed_ratio() requires a non-zero "
+                "duration"
+            )
+            raise ValueError(msg)
+        return self.elapsed_time(current).total_seconds() / total_seconds
 
     @property
     def end_of_first_quarter(self) -> datetime.datetime:


### PR DESCRIPTION
Summary:
- raise a clear ValueError when DateTimeRange.time_elapsed_ratio() is called on a zero-duration range
- add a regression test for DateTimeRange(begin, begin)

Validation:
- uv run poe check
- uv run poe test
- uv run poe coverage-xml
- uv build
- uv run ruff check timevec tests
- actionlint .github/workflows/*.yml
- git diff --check
