### PR TITLE
fix: make datetime64 conversion timezone-independent

### DIFF
--- a/tests/test_numpy_datetime64.py
+++ b/tests/test_numpy_datetime64.py
@@ -1,9 +1,26 @@
 import datetime
+import os
+import time
+from collections.abc import Iterator
 
 import numpy as np
+import pytest
 
 import timevec.numpy as tv
 import timevec.numpy_datetime64 as tv64
+
+
+@pytest.fixture
+def timezone() -> Iterator[None]:
+    old_tz = os.environ.get("TZ")
+    try:
+        yield
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
 
 
 def test_long_time_vec() -> None:
@@ -55,6 +72,27 @@ def test_multiple_datetime64() -> None:
     assert vec.shape == (3,)
     vec2 = np.frompyfunc(tv64.day_vec, 1, 1)(vec)
     assert np.stack(vec2, axis=0).shape == (3, 2)
-    vec3 = np.array([[dt64, dt64, dt64],
-                     [dt64, dt64, dt64]], dtype=np.datetime64)
+    vec3 = np.array(
+        [[dt64, dt64, dt64], [dt64, dt64, dt64]],
+        dtype=np.datetime64,
+    )
     assert vec3.shape == (2, 3)
+
+
+@pytest.mark.skipif(
+    not hasattr(time, "tzset"),
+    reason="timezone switching requires time.tzset()",
+)
+@pytest.mark.usefixtures("timezone")
+def test_datetime_to_datetime64_is_timezone_independent() -> None:
+    dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
+
+    os.environ["TZ"] = "UTC"
+    time.tzset()
+    utc_result = tv64.datetime_to_datetime64(dt)
+
+    os.environ["TZ"] = "Asia/Tokyo"
+    time.tzset()
+    tokyo_result = tv64.datetime_to_datetime64(dt)
+
+    assert utc_result == tokyo_result == np.datetime64("2024-01-01T12:00:00")

--- a/timevec/numpy_datetime64.py
+++ b/timevec/numpy_datetime64.py
@@ -9,7 +9,9 @@ import timevec.util as util
 
 
 def long_time_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the long time as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -19,7 +21,9 @@ def long_time_vec(
 
 
 def millennium_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the millennium as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -29,7 +33,9 @@ def millennium_vec(
 
 
 def century_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the century as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -39,7 +45,9 @@ def century_vec(
 
 
 def year_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the year as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -49,7 +57,9 @@ def year_vec(
 
 
 def month_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the month as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -59,7 +69,9 @@ def month_vec(
 
 
 def week_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the week as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -69,7 +81,9 @@ def week_vec(
 
 
 def day_vec(
-    dt: np.datetime64, *, dtype: npt.DTypeLike = np.float64,
+    dt: np.datetime64,
+    *,
+    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray:
     """Represent the elapsed time in the day as a vector"""
     dt2 = datetime64_to_datetime(dt)
@@ -84,12 +98,19 @@ def datetime64_to_datetime(dt: np.datetime64) -> datetime.datetime:
     ts = float(
         (dt64 - np.datetime64("1970-01-01T00:00:00")) / np.timedelta64(1, "s"),
     )
-    return datetime.datetime.utcfromtimestamp(ts)
+    return datetime.datetime.fromtimestamp(
+        ts,
+        datetime.timezone.utc,
+    ).replace(tzinfo=None)
 
 
 def datetime_to_datetime64(dt: datetime.datetime) -> np.datetime64:
     """Convert a datetime.datetime to a numpy.datetime64"""
-    ts = dt.timestamp()
+    if dt.tzinfo is None:
+        dt_utc = dt.replace(tzinfo=datetime.timezone.utc)
+    else:
+        dt_utc = dt
+    ts = dt_utc.timestamp()
     return np.datetime64("1970-01-01T00:00:00") + np.timedelta64(int(ts), "s")
 
 


### PR DESCRIPTION
Summary:
- treat naive datetime inputs as UTC when converting to numpy.datetime64
- keep datetime64-to-datetime conversion on a naive UTC contract without using deprecated utcfromtimestamp()
- add a timezone-switching regression test

Validation:
- uv run poe check
- uv run poe test
- uv run poe coverage-xml
- uv build
- uv run ruff check timevec tests
- actionlint .github/workflows/*.yml
- git diff --check
