### PR TITLE
Preserve microsecond precision in datetime_to_datetime64

### DIFF
--- a/examples/plot.py
+++ b/examples/plot.py
@@ -9,7 +9,10 @@ import numpy as np
 import timevec.numpy as tv
 
 
-def plot_func_vec(func: Callable[[datetime.datetime], np.ndarray], dates: list[datetime.datetime]) -> None:
+def plot_func_vec(
+    func: Callable[[datetime.datetime], np.ndarray],
+    dates: list[datetime.datetime],
+) -> None:
     vecs = np.array([func(dt) for dt in dates])
     _fig, _ax = plt.subplots()
     plt.plot(vecs)
@@ -17,22 +20,38 @@ def plot_func_vec(func: Callable[[datetime.datetime], np.ndarray], dates: list[d
 
 
 def main() -> None:
-    plot_func_vec(tv.year_vec, dates=[
-        datetime.datetime(2023, 1, 1, 0, 0, 0) + datetime.timedelta(days=day)
-        for day in range(365 * 2)
-    ])
-    plot_func_vec(tv.month_vec, dates=[
-        datetime.datetime(2023, 1, 1, 0, 0, 0) + datetime.timedelta(days=day)
-        for day in range(31 * 2)
-    ])
-    plot_func_vec(tv.week_vec, dates=[
-        datetime.datetime(2023, 1, 1, 0, 0, 0) + datetime.timedelta(hours=h)
-        for h in range(24 * 7 * 2)
-    ])
-    plot_func_vec(tv.day_vec, dates=[
-        datetime.datetime(2023, 1, 1, 0, 0, 0) + datetime.timedelta(hours=h)
-        for h in range(24 * 2)
-    ])
+    plot_func_vec(
+        tv.year_vec,
+        dates=[
+            datetime.datetime(2023, 1, 1, 0, 0, 0)
+            + datetime.timedelta(days=day)
+            for day in range(365 * 2)
+        ],
+    )
+    plot_func_vec(
+        tv.month_vec,
+        dates=[
+            datetime.datetime(2023, 1, 1, 0, 0, 0)
+            + datetime.timedelta(days=day)
+            for day in range(31 * 2)
+        ],
+    )
+    plot_func_vec(
+        tv.week_vec,
+        dates=[
+            datetime.datetime(2023, 1, 1, 0, 0, 0)
+            + datetime.timedelta(hours=h)
+            for h in range(24 * 7 * 2)
+        ],
+    )
+    plot_func_vec(
+        tv.day_vec,
+        dates=[
+            datetime.datetime(2023, 1, 1, 0, 0, 0)
+            + datetime.timedelta(hours=h)
+            for h in range(24 * 2)
+        ],
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_builtin_math.py
+++ b/tests/test_builtin_math.py
@@ -48,8 +48,14 @@ def assert_range_vector_value(
 ) -> None:
     assert fn(range.begin) == pytest.approx((1.0, 0.0), abs=abs)
     assert fn(range.end_of_first_quarter) == pytest.approx((0.0, 1.0), abs=abs)
-    assert fn(range.end_of_second_quarter) == pytest.approx((-1.0, 0.0), abs=abs)
-    assert fn(range.end_of_third_quarter) == pytest.approx((0.0, -1.0), abs=abs)
+    assert fn(range.end_of_second_quarter) == pytest.approx(
+        (-1.0, 0.0),
+        abs=abs,
+    )
+    assert fn(range.end_of_third_quarter) == pytest.approx(
+        (0.0, -1.0),
+        abs=abs,
+    )
     assert fn(range.end) == pytest.approx((1.0, 0.0), abs=abs)
 
 

--- a/tests/test_many_dates.py
+++ b/tests/test_many_dates.py
@@ -23,7 +23,16 @@ def test_many_dates() -> None:
             "week",
             "day",
         ]
-    ] = ["long_time", "millennium", "century", "decade", "year", "month", "week", "day"]
+    ] = [
+        "long_time",
+        "millennium",
+        "century",
+        "decade",
+        "year",
+        "month",
+        "week",
+        "day",
+    ]
     minimal: Iterable[Literal["long_time", "century", "year", "day"]] = [
         "long_time",
         "century",

--- a/tests/test_numpy_datetime64.py
+++ b/tests/test_numpy_datetime64.py
@@ -23,6 +23,22 @@ def timezone() -> Iterator[None]:
         time.tzset()
 
 
+def test_datetime_to_datetime64_preserves_microseconds() -> None:
+    dt = datetime.datetime(
+        2024,
+        1,
+        1,
+        12,
+        0,
+        0,
+        500000,
+        tzinfo=datetime.timezone.utc,
+    )
+    dt64 = tv64.datetime_to_datetime64(dt)
+    dt_back = tv64.datetime64_to_datetime(dt64)
+    assert dt_back.microsecond == dt.microsecond
+
+
 def test_long_time_vec() -> None:
     dt = datetime.datetime.now()
     dt64 = np.datetime64(dt)

--- a/tests/test_same_result.py
+++ b/tests/test_same_result.py
@@ -26,8 +26,16 @@ def assert_same(
     result1 = func1(dt)
     result2 = func2(dt)
     result3 = func3(np.datetime64(dt))
-    assert pytest.approx(result1[0], rel=rel_tol, abs=abs_tol) == result2[0] == result3[0]
-    assert pytest.approx(result1[1], rel=rel_tol, abs=abs_tol) == result2[1] == result3[1]
+    assert (
+        pytest.approx(result1[0], rel=rel_tol, abs=abs_tol)
+        == result2[0]
+        == result3[0]
+    )
+    assert (
+        pytest.approx(result1[1], rel=rel_tol, abs=abs_tol)
+        == result2[1]
+        == result3[1]
+    )
 
 
 def random_date() -> datetime.datetime:
@@ -49,13 +57,23 @@ def random_dates(size: int = 2000) -> list[datetime.datetime]:
 def test_long_time_vec() -> None:
     test_dates = random_dates()
     for dt in test_dates:
-        assert_same(dt, tv.long_time_vec, tvn.long_time_vec, tv64.long_time_vec)
+        assert_same(
+            dt,
+            tv.long_time_vec,
+            tvn.long_time_vec,
+            tv64.long_time_vec,
+        )
 
 
 def test_millennium_vec() -> None:
     test_dates = random_dates()
     for dt in test_dates:
-        assert_same(dt, tv.millennium_vec, tvn.millennium_vec, tv64.millennium_vec)
+        assert_same(
+            dt,
+            tv.millennium_vec,
+            tvn.millennium_vec,
+            tv64.millennium_vec,
+        )
 
 
 def test_century_vec() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -31,7 +31,8 @@ def assert_date_time_range(range: DateTimeRange) -> None:
 def test_date_time_range() -> None:
     """Test DateTimeRange"""
     range = DateTimeRange(
-        datetime.datetime(2000, 1, 1), datetime.datetime(2000, 1, 2),
+        datetime.datetime(2000, 1, 1),
+        datetime.datetime(2000, 1, 2),
     )
     assert_date_time_range(range)
     assert range.begin == datetime.datetime(2000, 1, 1)

--- a/timevec/numpy_datetime64.py
+++ b/timevec/numpy_datetime64.py
@@ -123,7 +123,10 @@ def datetime_to_datetime64(dt: datetime.datetime) -> np.datetime64:
     else:
         dt_utc = dt
     ts = dt_utc.timestamp()
-    return np.datetime64("1970-01-01T00:00:00") + np.timedelta64(int(ts), "s")
+    return np.datetime64("1970-01-01T00:00:00") + np.timedelta64(
+        round(ts * 1_000_000),
+        "us",
+    )
 
 
 def datetime64_to_vecs(


### PR DESCRIPTION
## Summary

`datetime_to_datetime64` used `int(ts)` to convert a `datetime.datetime` timestamp
to a `numpy.datetime64`, silently truncating any sub-second components.

- Before: `np.timedelta64(int(ts), "s")` — second precision only
- After: `np.timedelta64(round(ts * 1_000_000), "us")` — microsecond precision

This makes the `datetime → datetime64 → datetime` round-trip lossless for
datetimes that carry microseconds.

## Changes

- `timevec/numpy_datetime64.py`: use `"us"` unit instead of `"s"`
- `tests/test_numpy_datetime64.py`: add round-trip test for microseconds