### PR TITLE
fix: use math.floor instead of int() for pre-epoch datetime64 conversion

### DIFF
--- a/tests/test_numpy_datetime64.py
+++ b/tests/test_numpy_datetime64.py
@@ -8,6 +8,7 @@ import pytest
 
 import timevec.numpy as tv
 import timevec.numpy_datetime64 as tv64
+from timevec.numpy_datetime64 import datetime_to_datetime64
 
 
 @pytest.fixture
@@ -63,6 +64,16 @@ def test_day_vec() -> None:
     dt = datetime.datetime.now()
     dt64 = np.datetime64(dt)
     assert np.allclose(tv64.day_vec(dt64), tv.day_vec(dt))
+
+
+def test_datetime_to_datetime64_pre_epoch_floor() -> None:
+    # pre-epoch datetime with sub-second uses math.floor (toward -inf), not int() (toward zero).
+    # For a negative timestamp, int() truncates toward zero = 1 second too late.
+    # math.floor() truncates toward -inf = correct second boundary.
+    dt = datetime.datetime(1950, 6, 15, 12, 0, 0, 500000, tzinfo=datetime.timezone.utc)
+    result = datetime_to_datetime64(dt)
+    # floor of 1950-06-15T12:00:00.5 UTC → 1950-06-15T12:00:00 (not T12:00:01)
+    assert result == np.datetime64("1950-06-15T12:00:00")
 
 
 def test_multiple_datetime64() -> None:

--- a/timevec/numpy_datetime64.py
+++ b/timevec/numpy_datetime64.py
@@ -1,4 +1,5 @@
 import datetime
+import math
 from collections.abc import Iterable
 
 import numpy as np
@@ -123,7 +124,9 @@ def datetime_to_datetime64(dt: datetime.datetime) -> np.datetime64:
     else:
         dt_utc = dt
     ts = dt_utc.timestamp()
-    return np.datetime64("1970-01-01T00:00:00") + np.timedelta64(int(ts), "s")
+    return np.datetime64("1970-01-01T00:00:00") + np.timedelta64(
+        math.floor(ts), "s",
+    )
 
 
 def datetime64_to_vecs(


### PR DESCRIPTION
## Summary

`datetime_to_datetime64` used `int(ts)` to convert a Unix timestamp to seconds.
For pre-epoch datetimes (timestamps before 1970-01-01), `int()` truncates toward
zero, which rounds up by one second for any datetime with a non-zero sub-second
component. `math.floor()` always truncates toward negative infinity, giving the
correct second boundary.

- Before: `np.timedelta64(int(ts), "s")` — `int(-0.5)` == 0 (wrong for pre-epoch)
- After: `np.timedelta64(math.floor(ts), "s")` — `math.floor(-0.5)` == -1 (correct)

**Example**: `datetime(1950, 6, 15, 12, 0, 0, 500000, utc)` has a fractional
negative timestamp. With `int()`, the result is 1 second too late; with
`math.floor()`, the result is the correct second boundary.

## Changes

- `timevec/numpy_datetime64.py`: replace `int(ts)` with `math.floor(ts)`, add `import math`
- `tests/test_numpy_datetime64.py`: add regression test for the pre-epoch floor case

## Test plan

- [x] `test_datetime_to_datetime64_pre_epoch_floor`: verifies a 1950 datetime with
  microseconds maps to the correct second boundary, not `+1s`
