### PR TITLE
Migrate PyPI publish workflow to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -41,13 +42,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `id-token: write` permission to the `deploy` job
- Remove legacy API token authentication (`user: __token__` + `password: ${{ secrets.PYPI_API_TOKEN }}` / `TEST_PYPI_API_TOKEN`) from both publish steps
- `pypa/gh-action-pypi-publish` automatically uses OIDC when `id-token: write` is granted and no credentials are specified

## Why

The current workflow uses legacy API token authentication, which requires storing long-lived tokens in GitHub Secrets. PyPI's [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) with GitHub Actions OIDC eliminates the need to manage API tokens entirely — authentication is federated between GitHub Actions and PyPI with no long-lived secret involved.

## Required action before merging

Before merging this PR, configure a Trusted Publisher on PyPI:

1. Go to https://pypi.org/manage/account/publishing/ (for PyPI) and https://test.pypi.org/manage/account/publishing/ (for Test PyPI)
2. Add a new pending publisher with:
   - PyPI project name: `python-timevec`
   - Owner: `kitsuyui`
   - Repository name: `python-timevec`
   - Workflow name: `pypi-publish.yml`
   - Environment: (leave empty)

After configuring Trusted Publishers on both PyPI and Test PyPI, the `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` secrets can be removed from the repository settings.

## Trade-offs

- **Pros**: Eliminates long-lived API tokens; no token rotation needed; improved security posture
- **Cons**: Requires one-time manual configuration of Trusted Publishers on PyPI/Test PyPI before merging
