### PR TITLE
fix(builtin_math): raise ValueError when datetime_from_vecs receives no recognized targets

### DIFF
--- a/tests/test_builtin_math.py
+++ b/tests/test_builtin_math.py
@@ -183,3 +183,13 @@ def test_edge_cases() -> None:
 def test_vec_to_ratio_zero_vector_raises() -> None:
     with pytest.raises(ValueError):
         tv.vec_to_ratio(0.0, 0.0)
+
+
+def test_datetime_from_vecs_empty_raises() -> None:
+    with pytest.raises(ValueError, match="No recognized time targets"):
+        tv.datetime_from_vecs({})
+
+
+def test_datetime_from_vecs_unrecognized_keys_raises() -> None:
+    with pytest.raises(ValueError, match="No recognized time targets"):
+        tv.datetime_from_vecs({"unknown_key": (0.5, 0.5)})  # type: ignore[dict-item]

--- a/timevec/builtin_math.py
+++ b/timevec/builtin_math.py
@@ -134,9 +134,20 @@ def datetime_to_vecs(
 def datetime_from_vecs(
     items: dict[util.TARGET, tuple[float, float]],
 ) -> datetime.datetime:
-    """Convert a vector to a datetime"""
+    """Convert a vector to a datetime.
+
+    Raises:
+        ValueError: If no recognized time targets are present in *items*.
+    """
+    ranges = list(present_ranges(items))
+    if not ranges:
+        valid = [target for target, _ in RANGE_FACTORIES]
+        raise ValueError(
+            f"No recognized time targets in items. "
+            f"Expected one or more of {valid}; got {list(items.keys())}.",
+        )
     t = util.BEGIN_OF_DATETIME
-    for range_factory, value in present_ranges(items):
+    for range_factory, value in ranges:
         range = range_factory(t)
         t = range.current_time_by_ratio(vec_to_ratio(*value))
     return t


### PR DESCRIPTION
## Summary

`datetime_from_vecs({})` silently returned `datetime(1, 1, 1, 0, 0, 0)` (`BEGIN_OF_DATETIME`) when called with an empty dict or a dict containing only unrecognized keys, because the internal `for` loop over `present_ranges({})` never executed. Callers had no way to detect the invalid input from the return value.

## Changes

- **`timevec/builtin_math.py`**: Collect `present_ranges(items)` into a list, check if it is empty, and raise `ValueError` with a message listing valid target keys and the keys that were actually supplied.
- **`tests/test_builtin_math.py`**: Add tests for the empty-dict case and the unrecognized-keys case.

## Verification

- All 40 tests pass (`uv run pytest tests/`).
- `ruff check timevec tests` and `mypy timevec tests`: no issues.
- Additional static check: `ruff check --select=ERA,RUF,B`: 0 findings.

## Trade-offs

Raising `ValueError` immediately makes the error visible at call time. The alternative of returning a sentinel value (`None` or `BEGIN_OF_DATETIME`) would require callers to check the return value on every call. Changing the return type to `Optional[datetime]` was considered but rejected because it would require callers to handle `None` even in the common non-empty case.
