### PR TITLE
fix: warn on unexpected ImportError in optional submodule imports

### DIFF
--- a/timevec/__init__.py
+++ b/timevec/__init__.py
@@ -15,18 +15,42 @@ it is desirable that the value is close to 00:00 on the next day.
 To achieve this, the time is represented as a combination of cos and sin."""
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
-import contextlib
+import warnings
 
 from ._version import __version__
 
-with contextlib.suppress(ImportError):
+try:
     from . import builtin_math
+except ModuleNotFoundError:
+    pass
+except ImportError as e:
+    warnings.warn(
+        f"timevec.builtin_math could not be imported: {e}",
+        ImportWarning,
+        stacklevel=2,
+    )
 
-with contextlib.suppress(ImportError):
+try:
     from . import numpy_datetime64
+except ModuleNotFoundError:
+    pass
+except ImportError as e:
+    warnings.warn(
+        f"timevec.numpy_datetime64 could not be imported: {e}",
+        ImportWarning,
+        stacklevel=2,
+    )
 
-with contextlib.suppress(ImportError):
+try:
     from . import numpy
+except ModuleNotFoundError:
+    pass
+except ImportError as e:
+    warnings.warn(
+        f"timevec.numpy could not be imported: {e}",
+        ImportWarning,
+        stacklevel=2,
+    )
 
 
 __all__ = ["__version__", "builtin_math", "numpy", "numpy_datetime64"]


### PR DESCRIPTION
## Summary

`timevec/__init__.py` used `contextlib.suppress(ImportError)` to handle optional
submodule imports (`builtin_math`, `numpy_datetime64`, `numpy`). This silently
discarded all import failures, including cases where a package is installed but
cannot be imported due to ABI incompatibility, partial installation, or broken
native extensions.

When such a failure occurs, users encounter `AttributeError: module 'timevec'
has no attribute 'numpy'` with no diagnostic information about the original cause.

## Changes

Replace each `contextlib.suppress(ImportError)` block with explicit try/except:

- `ModuleNotFoundError` (module not installed): silently ignored — expected behavior
- Other `ImportError` subtypes (broken installation): emit `warnings.warn()` with
  the original exception message, so users can diagnose the root cause

## Verification

- 38 tests pass (`uv run poe test`)
- Lint clean (`uv run ruff check timevec tests`)
- Typecheck clean (`uv run mypy timevec tests`)