### PR TITLE
Enforce begin <= end invariant in DateTimeRange at construction time

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -48,6 +48,14 @@ def test_time_elapsed_ratio_rejects_zero_duration_range() -> None:
         range.time_elapsed_ratio(instant)
 
 
+def test_date_time_range_inverted_raises() -> None:
+    """DateTimeRange with begin > end must raise ValueError."""
+    with pytest.raises(ValueError):
+        DateTimeRange(
+            datetime.datetime(2000, 1, 2), datetime.datetime(2000, 1, 1),
+        )
+
+
 def test_long_time_range() -> None:
     """Test long_time_range()"""
     range = long_time_range(datetime.datetime(2000, 1, 1))

--- a/timevec/util.py
+++ b/timevec/util.py
@@ -20,6 +20,12 @@ class DateTimeRange:
     begin: datetime.datetime
     end: datetime.datetime
 
+    def __post_init__(self) -> None:
+        if self.begin > self.end:
+            raise ValueError(
+                f"begin must not be after end: {self.begin!r} > {self.end!r}",
+            )
+
     @property
     def total_time(self) -> datetime.timedelta:
         return self.end - self.begin


### PR DESCRIPTION
## Summary

`DateTimeRange` is a public `@dataclass` with methods that assume `begin < end`, but the constraint was not enforced at construction time. Passing `begin > end` would silently produce:

- Negative `total_time` (via `end - begin`)
- Negative ratio from `time_elapsed_ratio` (ratio falls outside `[0, 1)`)
- Incorrect vectors from downstream `ratio_to_vec` calls (no range check)

The bug is silent — no exception is raised and the bad value propagates to the caller.

## Change

Add `__post_init__` to `DateTimeRange` that raises `ValueError` when `begin > end`:

```python
def __post_init__(self) -> None:
    if self.begin > self.end:
        raise ValueError(
            f"begin must not be after end: {self.begin!r} > {self.end!r}",
        )
```

Add a test that verifies the error is raised for an inverted range.

Also apply `ruff format` to `numpy.py` and `numpy_datetime64.py` (existing trailing-comma / line-length style fixes surfaced by the formatter).

## Verification

- `poe check` — ruff + mypy: no issues
- `poe test` — 39 tests pass (including the new test)