### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,34 @@ You can express periodicity such as morning, noon, and night.
 - `century_vec` ... one century (100 years) period
 - `decade_vec` ... one decade (10 years) period
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 # License
 
 BSD 3-Clause License

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` to mirror the same `poe check` and `poe test` tasks that CI runs, but locally on the developer's machine.
- CI (GitHub Actions) is kept completely unchanged — Actions remains free for public repos and continues to run the full matrix.

## Changes

- **`lefthook.yml`**: configures two hooks:
  - `pre-commit`: runs `uv run poe check` (ruff + mypy)
  - `pre-push`: runs `uv run poe check` and `uv run poe test`
  Each job unsets `GIT_*` environment variables first so nested/sibling repositories are not affected.
- **`README.md`**: adds a `## Development` section (inserted before `# License`) explaining how to install and use lefthook.

## Verification

- `uv run poe check` passes locally (ruff + mypy clean).
- `uv run poe test` passes locally (53 tests passed).
- `lefthook install` was run; the pre-commit hook fired and passed during the commit.
- The pre-push hook fired (both check and test) and passed during `git push`.

## Notes

- Requires `lefthook` on the developer's PATH (`lefthook install` is a one-time setup).
- No CI workflow files were modified.
