### PR TITLE
ci: add build provenance attestation to PyPI publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -40,6 +41,12 @@ jobs:
 
       - name: Build
         run: uv build
+
+      - name: Attest build provenance
+        if: github.event_name == 'release' && !github.event.release.prerelease
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/*
 
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
## Summary

Add SLSA build provenance attestation to the PyPI publish workflow using `actions/attest-build-provenance`.

## Changes

- Add `attestations: write` job permission (required by the action)
- Add `Attest build provenance` step after `uv build`, conditioned on non-prerelease releases only

The attestation step runs only for production releases (matching the existing PyPI publish condition), so test PyPI (prerelease) flows are unaffected.

## Verification

After this change, release artifacts (`dist/*.whl`, `dist/*.tar.gz`) will receive a GitHub-signed SLSA provenance attestation, verifiable with:

```sh
gh attestation verify <artifact> --repo kitsuyui/python-timevec
```

The `id-token: write` permission was already present (used for PyPI Trusted Publisher). No further configuration changes are needed.
