### PR TITLE
test: expand random_date to cover month-end days (29-31)

### DIFF
--- a/tests/test_same_result.py
+++ b/tests/test_same_result.py
@@ -1,6 +1,7 @@
 # Test if the function implemented with numpy and the function implemented with builtin math return the same result.
 from __future__ import annotations
 
+import calendar
 import datetime
 import random
 from collections.abc import Callable
@@ -44,7 +45,8 @@ def random_date() -> datetime.datetime:
     """Return a random datetime between 1990-01-01 and 2030-12-31."""
     year = random.randint(1990, 2030)
     month = random.randint(1, 12)
-    day = random.randint(1, 28)
+    _, last_day = calendar.monthrange(year, month)
+    day = random.randint(1, last_day)
     hour = random.randint(0, 23)
     minute = random.randint(0, 59)
     second = random.randint(0, 59)
@@ -94,6 +96,19 @@ def test_month_vec() -> None:
     test_dates = random_dates()
     for dt in test_dates:
         assert_same(dt, tv.month_vec, tvn.month_vec, tv64.month_vec)
+
+
+@pytest.mark.parametrize(
+    "dt",
+    [
+        datetime.datetime(2000, 1, 31, 23, 59, 59),  # 31-day month end
+        datetime.datetime(2000, 4, 30, 23, 59, 59),  # 30-day month end
+        datetime.datetime(2000, 2, 29, 23, 59, 59),  # leap year Feb end
+        datetime.datetime(2001, 2, 28, 23, 59, 59),  # non-leap year Feb end
+    ],
+)
+def test_month_vec_at_month_end(dt: datetime.datetime) -> None:
+    assert_same(dt, tv.month_vec, tvn.month_vec, tv64.month_vec)
 
 
 def test_week_vec() -> None:


### PR DESCRIPTION
## Problem

`random_date()` in `tests/test_same_result.py` generated dates with
`day = random.randint(1, 28)`, so days 29–31 were never sampled.
As a result, `test_month_vec` never exercised `month_range` with a
month-end date, leaving the `calendar.monthrange` path untested for
months with 29, 30, or 31 days.

The docstring claimed a range of 1990-01-01 to 2030-12-31 with no
mention of this constraint, making the gap a silent assumption.

## Change

- Import `calendar` in the test file.
- Replace `day = random.randint(1, 28)` with
  `_, last_day = calendar.monthrange(year, month); day = random.randint(1, last_day)`.
  Random dates now uniformly cover all valid days in each month.
- Add `test_month_vec_at_month_end`: a parametrized test that explicitly
  asserts `month_vec` consistency for four known month-end datetimes
  (Jan 31, Apr 30, Feb 29 leap, Feb 28 non-leap).

## Verification

- All 58 tests pass (`uv run pytest`).
- `ruff check` and `ruff format --check` clean.
- `mypy` clean on the modified file.

## Trade-offs

The random test now has a small probability of generating a 29th, 30th,
or 31st; combined with the deterministic parametrized cases this gives
reliable coverage without relying on luck.
