### PR TITLE
test: correct many-dates range comment

### DIFF
--- a/tests/test_many_dates.py
+++ b/tests/test_many_dates.py
@@ -66,5 +66,5 @@ def test_many_dates() -> None:
         vecs7 = tv64.datetime64_to_vecs(np.datetime64(dt), minimal)
         tv64.datetime64_from_vecs(vecs7)
 
-    # tested up to 2100-01-01
+    # tested beyond 2400-01-01
     assert dt >= datetime.datetime(2400, 1, 1, 0, 0, 0)


### PR DESCRIPTION
## Summary
- update the many-dates test comment so it matches the adjacent 2400-01-01 assertion
- keep the test behavior unchanged

## Tests
- uv run poe check
- uv run poe test
- uv run poe coverage-xml
- uv build
- actionlint .github/workflows/*.yml
- docker run --rm --network=none -v "$PWD:/workspace" -w /workspace audit-toolchain:dev ruff check tests/test_many_dates.py
- uv run ruff format --check tests/test_many_dates.py
- typos tests/test_many_dates.py
- git diff --check
- check-pr-collateral: clean
