### PR TITLE
test: seed random before each test for reproducibility

### DIFF
--- a/tests/test_same_result.py
+++ b/tests/test_same_result.py
@@ -15,6 +15,11 @@ import timevec.numpy as tvn
 import timevec.numpy_datetime64 as tv64
 
 
+@pytest.fixture(autouse=True)
+def _seed_random() -> None:
+    random.seed(0)
+
+
 def assert_same(
     dt: datetime.datetime,
     func1: Callable[[datetime.datetime], tuple[float, float]],


### PR DESCRIPTION
## Summary

- Add an `autouse=True` pytest fixture that calls `random.seed(0)` before each
  test function in `tests/test_same_result.py`.
- Previously, `random_date()` relied on OS-entropy seeding, so the 2000 random
  dates generated per test varied between runs, making CI failures impossible
  to reproduce.

## Motivation

`random_date()` uses `random.randint()` throughout. Without a fixed seed the
random state is set by OS entropy at process start, meaning each run produces
a different sequence. If a test fails, there is no way to reconstruct the exact
input that triggered the failure.

## Change

```python
@pytest.fixture(autouse=True)
def _seed_random() -> None:
    random.seed(0)
```

This fixture runs before every test in the file and resets the global
`random` state to a deterministic sequence, so failures are reproducible.
Each test receives an independent seed (not a continuation of the previous
test's state), preserving test isolation.

## Verification

- `ruff check tests/test_same_result.py` — no issues
- `ruff format --check tests/test_same_result.py` — already formatted
- `mypy tests/test_same_result.py` — no issues
- `pytest tests/` — 54 passed