### PR TITLE
fix: reject datetime vectors without known targets

### DIFF
--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -144,3 +144,15 @@ def test_edge_cases() -> None:
 def test_vec_to_ratio_zero_vector_raises() -> None:
     with pytest.raises(ValueError):
         tvn.vec_to_ratio(np.array([0.0, 0.0]))
+
+
+def test_datetime_from_vecs_empty_raises() -> None:
+    with pytest.raises(ValueError, match="No recognized time targets"):
+        tvn.datetime_from_vecs({})
+
+
+def test_datetime_from_vecs_unrecognized_keys_raises() -> None:
+    with pytest.raises(ValueError, match="No recognized time targets"):
+        tvn.datetime_from_vecs(
+            {"unknown_key": np.array([0.5, 0.5])},  # type: ignore[dict-item]
+        )

--- a/tests/test_numpy_datetime64.py
+++ b/tests/test_numpy_datetime64.py
@@ -133,3 +133,15 @@ def test_datetime_to_datetime64_is_timezone_independent() -> None:
     tokyo_result = tv64.datetime_to_datetime64(dt)
 
     assert utc_result == tokyo_result == np.datetime64("2024-01-01T12:00:00")
+
+
+def test_datetime64_from_vecs_empty_raises() -> None:
+    with pytest.raises(ValueError, match="No recognized time targets"):
+        tv64.datetime64_from_vecs({})
+
+
+def test_datetime64_from_vecs_unrecognized_keys_raises() -> None:
+    with pytest.raises(ValueError, match="No recognized time targets"):
+        tv64.datetime64_from_vecs(
+            {"unknown_key": np.array([0.5, 0.5])},  # type: ignore[dict-item]
+        )

--- a/timevec/numpy.py
+++ b/timevec/numpy.py
@@ -182,9 +182,20 @@ def datetime_to_vecs(
 def datetime_from_vecs(
     items: dict[util.TARGET, npt.NDArray[Any]],
 ) -> datetime.datetime:
-    """Convert a vector to a datetime"""
+    """Convert a vector to a datetime.
+
+    Raises:
+        ValueError: If no recognized time targets are present in *items*.
+    """
+    ranges = list(present_numpy_ranges(items))
+    if not ranges:
+        valid = [target for target, _ in NUMPY_RANGE_FACTORIES]
+        raise ValueError(
+            f"No recognized time targets in items. "
+            f"Expected one or more of {valid}; got {list(items.keys())}.",
+        )
     t = util.BEGIN_OF_DATETIME
-    for range_factory, value in present_numpy_ranges(items):
+    for range_factory, value in ranges:
         range = range_factory(t)
         t = range.current_time_by_ratio(vec_to_ratio(value))
     return t


### PR DESCRIPTION
## Summary

- reject empty or unrecognized datetime vector inputs in `timevec.numpy.datetime_from_vecs`
- keep `timevec.numpy_datetime64.datetime64_from_vecs` aligned through its existing delegation path
- add regression tests for both NumPy-backed public entry points

## Impact

- invalid inputs now fail with `ValueError` instead of silently returning the year-1 baseline datetime
- NumPy-backed conversion behavior now matches the existing builtin contract for missing recognized targets

## Validation

- `uv run poe check`
- `uv run poe test`
