### PR TITLE
fix: clamp week ranges near datetime.max

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -177,3 +177,11 @@ def test_millennium_range_near_datetime_max() -> None:
     assert range.begin.year == 9001
     assert range.end == datetime.datetime.max
     assert range.begin < range.end
+
+
+def test_week_range_near_datetime_max() -> None:
+    """week_range must clamp its end near datetime.max."""
+    range = week_range(datetime.datetime(9999, 12, 31))
+    assert range.begin == datetime.datetime(9999, 12, 27)
+    assert range.end == datetime.datetime.max
+    assert range.begin < range.end

--- a/timevec/util.py
+++ b/timevec/util.py
@@ -198,22 +198,19 @@ def week_range(
     dt: datetime.datetime,
 ) -> DateTimeRange:
     """Return a DateTimeRange that covers a week"""
-    begin_of_week = datetime.datetime.min.replace(
+    day_start = datetime.datetime.min.replace(
         year=dt.year,
         month=dt.month,
         day=dt.day,
         hour=0,
         minute=0,
         second=0,
-    ) - datetime.timedelta(days=dt.weekday())
-    end_of_week = datetime.datetime.min.replace(
-        year=dt.year,
-        month=dt.month,
-        day=dt.day,
-        hour=0,
-        minute=0,
-        second=0,
-    ) + datetime.timedelta(days=7 - dt.weekday())
+    )
+    begin_of_week = day_start - datetime.timedelta(days=dt.weekday())
+    try:
+        end_of_week = day_start + datetime.timedelta(days=7 - dt.weekday())
+    except OverflowError:
+        end_of_week = END_OF_DATETIME
     return DateTimeRange(begin_of_week, end_of_week)
 
 


### PR DESCRIPTION
## Summary
- clamp `week_range()` to `datetime.max` when the last week of year 9999 would overflow
- add a regression test covering `datetime.datetime(9999, 12, 31)`

## Impact
- `week_vec()` and other week-based helpers now keep working near `datetime.max` instead of raising `OverflowError`

## Testing
- `uv run poe check`
- `uv run poe test`
